### PR TITLE
Generating abbrevations *à la* `pack` for mixin and factory types

### DIFF
--- a/demo2.v
+++ b/demo2.v
@@ -23,11 +23,11 @@ Notation "[find v | t1 ∼ t2 | msg ] rest" :=
   form_scope.
 Definition id_phant {T} {t : T} (x : phantom T t) := x.
 
-Register unify as phant.unify.
-Register id_phant as phant.id.
-Register Coq.Init.Datatypes.None as elpi.none.
-Register Coq.Init.Datatypes.Some as elpi.some.
-Register Coq.Init.Datatypes.pair as elpi.pair.
+Register unify as hb.unify.
+Register id_phant as hb.id.
+Register Coq.Init.Datatypes.None as hb.none.
+Register Coq.Init.Datatypes.Some as hb.some.
+Register Coq.Init.Datatypes.pair as hb.pair.
 
 
 (* %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% *)
@@ -270,9 +270,8 @@ eta-mixin T F [M|ML] (fun `m` MTXL FmML) :- std.do! [
 % fun m_0 .. m_{i-1} m_{i+1} .. m_n => F m_0 .. m_{i-1} X m_{i+1} .. m_n
 % thus instanciating an abstraction on mixin M by X
 pred subst-mixin i:term, i:@mixinname, i:term, o:term.
-subst-mixin (fun _ Tm F) M X TFX :-
-  safe-dest-app Tm (global M) _, !,
-  pi m\ copy m X => copy (F m) TFX.
+subst-mixin (fun _ Tm F) M X (F X) :-
+  safe-dest-app Tm (global M) _, dep1 M _, !.
 subst-mixin (fun N T F) M X (fun N T FX) :- !,
   pi m \ subst-mixin (F m) M X (FX m).
 
@@ -311,7 +310,7 @@ mk-phant-abbrev.term K F [real-arg N|AL] K'' (fun N _ AbbrevFx) :- !,
 mk-phant-abbrev.term K F [implicit-arg|AL] K' FAbbrev :- !,
   mk-phant-abbrev.term K {mk-app F [_]} AL K' FAbbrev.
 mk-phant-abbrev.term K F [unify-arg|AL] K' FAbbrev :- !,
-  mk-phant-abbrev.term K {mk-app F [{{lib:@phant.id _ _}}]} AL K' FAbbrev.
+  mk-phant-abbrev.term K {mk-app F [{{lib:@hb.id _ _}}]} AL K' FAbbrev.
 
 pred mk-phant-abbrev i:string, i:phant-term, o:@constant.
 mk-phant-abbrev N (phant-trm AL T) C :- std.do! [
@@ -326,7 +325,7 @@ mk-phant-abbrev N (phant-trm AL T) C :- std.do! [
 % is starts with unifing X1 and X2 and then outputs PF.
 pred mk-phant-unify i:term, i:term, i:phant-term, o:phant-term.
 mk-phant-unify X1 X2 (phant-trm AL F) (phant-trm [unify-arg|AL] UF) :-
-  UF = {{fun u : lib:phant.unify lp:X1 lp:X2 lib:elpi.none => lp:F}}.
+  UF = {{fun u : lib:hb.unify lp:X1 lp:X2 lib:hb.none => lp:F}}.
 
 % [mk-phant-implicit N Ty PF PUF] states that PUF is a phant-term
 % which quantifies [PF x] over [x : Ty] (with name N)
@@ -341,8 +340,8 @@ pred mk-phant-struct i:term, i:term, i:(term -> phant-term), o:phant-term.
 mk-phant-struct T SI PF (phant-trm [implicit-arg, unify-arg|AL] UF) :-
   get-structure-sort-projection SI Sort,
   pi s\ PF s = phant-trm AL (F s),
-  UF = {{fun (s : lp:SI) (u : lib:phant.unify lp:T (lp:Sort s)
-      (lib:elpi.some ("is not canonically a"%string, lp:SI))) => lp:(F s)}}.
+  UF = {{fun (s : lp:SI) (u : lib:hb.unify lp:T (lp:Sort s)
+      (lib:hb.some ("is not canonically a"%string, lp:SI))) => lp:(F s)}}.
 
 % [mk-phant-struct T CN PF PCF] states that PSF is a phant-term
 % which postulate a structure [s : SI] such that [T = sort s]

--- a/demo2.v
+++ b/demo2.v
@@ -272,7 +272,7 @@ subst-mixin (fun N T F) M X (fun N T FX) :- !,
 % - [id]  trigger unification as described in
 % /Canonical Structures for the working Coq user/ by Mahboubi and Tassi
 %
-% phant-arg encore these three kind of arguments
+% phant-arg encode these three kind of arguments
 % - [x_i] is encoded using [real-arg x_i]
 % - [_]              using [implicit-arg]
 % - [id]             using [unify-arg]
@@ -303,7 +303,7 @@ mk-phant-abbrev.term K F [unify-arg|AL] K' FAbbrev :- !,
 pred mk-phant-abbrev i:string, i:phant-term, o:@constant.
 mk-phant-abbrev N (phant-trm AL T) C :- std.do! [
   coq.typecheck T _TyT,
-  NC is N ^ "const",
+  NC is "phant_" ^ N,
   coq.env.add-const NC T _ ff ff C,
   mk-phant-abbrev.term 0 (global (const C)) AL NParams Abbrev,
   coq.notation.add-abbreviation N NParams Abbrev tt ff
@@ -348,6 +348,7 @@ mk-phant-mixins.class T CN (phant-trm AL F)
     get-structure-constructor SI SK,
     (pi c\ mk-phant-mixins.class-mixins T CN c CML (phant-trm AL F)
        (phant-trm AL' (Body c))),
+    % TODO: replace with a big {{}} and `[find _ | _ ~ _]` or generate using a ELPI predicate 
     SCF = fun `s` SI s \
           fun `_` (app [{{@unify}}, _, _, T, app [Sort, s],
             app [{{@Some}}, _,

--- a/demo2.v
+++ b/demo2.v
@@ -299,9 +299,10 @@ type phant-trm list phant-arg -> term -> phant-term.
 
 % A *pack* notation can be easiliy produced from a phant-term using
 % [mk-phant-abbrev N PT C], which states that C is a new constant
-% which name is N_const, and which produces a simple notation
+% which name is phant_N, and which produces a simple notation
 % with name N using the data of the phant-term PT to reconstruct a notation
-% [Notation N args := C args _ _ id _ id _ _ id] as described above.
+% [Notation N x0 .. xn := C x0 _ _ id .. xi .. _ id _ _ id]
+% as described above.
 pred mk-phant-abbrev.term i:int, i:term, i:list phant-arg, o:int, o:term.
 mk-phant-abbrev.term K F [] K F.
 mk-phant-abbrev.term K F [real-arg N|AL] K'' (fun N _ AbbrevFx) :- !,
@@ -686,9 +687,9 @@ main [TS|Args] :- !, std.do! [
   locate-term-argument TS T,
   std.map Args locate-term-argument FIL,
   std.map FIL coq.typecheck FITyL,
-  std.map FITyL extract-factory-name FAL,
-  factories-provide-mixins FAL ML MixinOrigin,
-  std.map2 FAL FIL (f\g\r\ r = factory-instance-for f g) FactoryInstance,
+  std.map FITyL extract-factory-name FNL,
+  factories-provide-mixins FNL ML MixinOrigin,
+  std.map2 FNL FIL (f\g\r\ r = factory-instance-for f g) FactoryInstance,
   findall-classes AllStructures,
   MixinOrigin =>
   FactoryInstance =>


### PR DESCRIPTION
This PR adds support for generating a `phant_id` / `unify` (see *Canonical Structures for the working Coq user* by Mahboubi & Tassi) based notation for mixin and factory types.
A minor extension is needed to generate `pack` and `clone` from this.