### PR TITLE
shortenings + new instance Qc + bugfixes

### DIFF
--- a/demo1/stage0.v
+++ b/demo1/stage0.v
@@ -62,8 +62,8 @@ End Theory.
 
 (* Instance *)
 
-Definition Z_ring_axioms : Ring_of_TYPE.axioms_ Z :=
-  Ring_of_TYPE.Axioms 0%Z 1%Z Z.add Z.opp Z.mul
+Definition Z_ring_axioms :=
+  Ring_of_TYPE.Axioms_ Z 0%Z 1%Z Z.add Z.opp Z.mul
     Z.add_assoc Z.add_comm Z.add_0_l Z.add_opp_diag_l
     Z.mul_assoc Z.mul_1_l Z.mul_1_r
     Z.mul_add_distr_r Z.mul_add_distr_l.

--- a/demo1/stage1.v
+++ b/demo1/stage1.v
@@ -55,14 +55,15 @@ Elpi hb.declare_factory Ring_of_TYPE A.
   }.
 
   Variable a : axioms.
-  Definition to_AddComoid_of_TYPE : AddComoid_of_TYPE.axioms_ A :=
-    AddComoid_of_TYPE.Axioms (zero a) (add a) (addrA _) (addrC _) (add0r _).
+  Definition to_AddComoid_of_TYPE :=
+    AddComoid_of_TYPE.Axioms_ A (zero a) (add a) (addrA _) (addrC _) (add0r _).
   Elpi hb.canonical A to_AddComoid_of_TYPE.
 
-  Definition to_Ring_of_AddComoid : Ring_of_AddComoid.axioms_ A :=
-    Ring_of_AddComoid.Axioms _ _ _ (addNr _) (mulrA _) (mul1r _)
+  Definition to_Ring_of_AddComoid :=
+    Ring_of_AddComoid.Axioms_ A _ _ _ (addNr _) (mulrA _) (mul1r _)
       (mulr1 _) (mulrDl _) (mulrDr _).
-Elpi hb.end to_AddComoid_of_TYPE to_Ring_of_AddComoid.
+  Elpi hb.canonical A to_Ring_of_AddComoid.
+Elpi hb.end.
 
 (* End change *)
 
@@ -102,8 +103,8 @@ End Theory.
 
 (* Instance *)
 
-Definition Z_ring_axioms : Ring_of_TYPE.axioms_ Z :=
-  Ring_of_TYPE.Axioms 0%Z 1%Z Z.add Z.opp Z.mul
+Definition Z_ring_axioms :=
+  Ring_of_TYPE.Axioms_ Z 0%Z 1%Z Z.add Z.opp Z.mul
     Z.add_assoc Z.add_comm Z.add_0_l Z.add_opp_diag_l
     Z.mul_assoc Z.mul_1_l Z.mul_1_r
     Z.mul_add_distr_r Z.mul_add_distr_l.

--- a/demo1/stage2.v
+++ b/demo1/stage2.v
@@ -41,13 +41,14 @@ Elpi hb.declare_factory AddAG_of_TYPE A.
 
   Variable a : axioms.
 
-  Definition to_AddComoid_of_TYPE : AddComoid_of_TYPE.axioms_ A :=
-    AddComoid_of_TYPE.Axioms (zero a) (add a) (addrA _) (addrC _) (add0r _).
+  Definition to_AddComoid_of_TYPE :=
+    AddComoid_of_TYPE.Axioms_ A (zero a) (add a) (addrA _) (addrC _) (add0r _).
   Elpi hb.canonical A to_AddComoid_of_TYPE.
 
-  Definition to_AddAG_of_AddComoid : AddAG_of_AddComoid.axioms_ A :=
-    AddAG_of_AddComoid.Axioms _ (addNr a).
-Elpi hb.end to_AddComoid_of_TYPE to_AddAG_of_AddComoid.
+  Definition to_AddAG_of_AddComoid :=
+    AddAG_of_AddComoid.Axioms_ A _ (addNr a).
+  Elpi hb.canonical A to_AddAG_of_AddComoid.
+Elpi hb.end.
 Elpi hb.structure AddAG AddAG_of_TYPE.axioms.
 
 Elpi hb.declare_mixin Ring_of_AddAG A AddAG.axioms.
@@ -75,14 +76,14 @@ Elpi hb.declare_factory Ring_of_AddComoid A AddComoid.axioms.
   }.
 
   Variable a : axioms.
-  Definition to_AddAG_of_AddComoid : AddAG_of_AddComoid.axioms_ A :=
-    AddAG_of_AddComoid.Axioms _ (addNr a).
+  Definition to_AddAG_of_AddComoid := AddAG_of_AddComoid.Axioms_ A _ (addNr a).
   Elpi hb.canonical A to_AddAG_of_AddComoid.
 
-  Definition to_Ring_of_AddAG : Ring_of_AddAG.axioms_ A :=
-    Ring_of_AddAG.Axioms _ _ (mulrA a) (mul1r a) (mulr1 a) (mulrDl a) (mulrDr a).
+  Definition to_Ring_of_AddAG := Ring_of_AddAG.Axioms_ A
+    _ _ (mulrA a) (mul1r a) (mulr1 a) (mulrDl a) (mulrDr a).
+  Elpi hb.canonical A to_Ring_of_AddAG.
 
-Elpi hb.end to_AddAG_of_AddComoid to_Ring_of_AddAG.
+Elpi hb.end.
 
 (* End change *)
 
@@ -105,14 +106,14 @@ Elpi hb.declare_factory Ring_of_TYPE A.
   }.
 
   Variable a : axioms.
-  Definition to_AddComoid_of_TYPE : AddComoid_of_TYPE.axioms_ A :=
-    AddComoid_of_TYPE.Axioms (zero a) (add a) (addrA _) (addrC _) (add0r _).
+  Definition to_AddComoid_of_TYPE := AddComoid_of_TYPE.Axioms_ A
+    (zero a) (add a) (addrA _) (addrC _) (add0r _).
   Elpi hb.canonical A to_AddComoid_of_TYPE.
 
-  Definition to_Ring_of_AddComoid : Ring_of_AddComoid.axioms_ A :=
-    Ring_of_AddComoid.Axioms _ _ _ (addNr _) (mulrA _) (mul1r _)
-      (mulr1 _) (mulrDl _) (mulrDr _).
-Elpi hb.end to_AddComoid_of_TYPE to_Ring_of_AddComoid.
+  Definition to_Ring_of_AddComoid := Ring_of_AddComoid.Axioms_ A
+    _ _ _ (addNr _) (mulrA _) (mul1r _) (mulr1 _) (mulrDl _) (mulrDr _).
+  Elpi hb.canonical A to_Ring_of_AddComoid.
+Elpi hb.end.
 
 Elpi hb.structure Ring Ring_of_TYPE.axioms.
 
@@ -150,8 +151,8 @@ End Theory.
 
 (* Instance *)
 
-Definition Z_ring_axioms : Ring_of_TYPE.axioms_ Z :=
-  Ring_of_TYPE.Axioms 0%Z 1%Z Z.add Z.opp Z.mul
+Definition Z_ring_axioms :=
+  Ring_of_TYPE.Axioms_ Z 0%Z 1%Z Z.add Z.opp Z.mul
     Z.add_assoc Z.add_comm Z.add_0_l Z.add_opp_diag_l
     Z.mul_assoc Z.mul_1_l Z.mul_1_r
     Z.mul_add_distr_r Z.mul_add_distr_l.

--- a/demo1/stage3.v
+++ b/demo1/stage3.v
@@ -41,13 +41,13 @@ Elpi hb.declare_factory AddAG_of_TYPE A.
 
   Variable a : axioms.
 
-  Definition to_AddComoid_of_TYPE : AddComoid_of_TYPE.axioms_ A :=
-    AddComoid_of_TYPE.Axioms (zero a) (add a) (addrA _) (addrC _) (add0r _).
+  Definition to_AddComoid_of_TYPE := AddComoid_of_TYPE.Axioms_ A
+    (zero a) (add a) (addrA _) (addrC _) (add0r _).
   Elpi hb.canonical A to_AddComoid_of_TYPE.
 
-  Definition to_AddAG_of_AddComoid : AddAG_of_AddComoid.axioms_ A :=
-    AddAG_of_AddComoid.Axioms _ (addNr a).
-Elpi hb.end to_AddComoid_of_TYPE to_AddAG_of_AddComoid.
+  Definition to_AddAG_of_AddComoid := AddAG_of_AddComoid.Axioms_ A _ (addNr a).
+  Elpi hb.canonical A to_AddAG_of_AddComoid.
+Elpi hb.end.
 Elpi hb.structure AddAG AddAG_of_TYPE.axioms.
 
 (* Begin change *)
@@ -94,11 +94,12 @@ Elpi hb.declare_factory Ring_of_AddAG A AddAG.axioms.
   by rewrite -mulrDr add0r addrC addNr.
   Qed.
 
-  Definition to_SemiRing_of_AddComoid : SemiRing_of_AddComoid.axioms_ A :=
-    SemiRing_of_AddComoid.Axioms _ (mul a) (mulrA a) (mulr1 a) (mul1r a)
-      (mulrDl a) (mulrDr a) (mul0r) (mulr0).
+  Definition to_SemiRing_of_AddComoid := SemiRing_of_AddComoid.Axioms_ A
+    _ (mul a) (mulrA a) (mulr1 a) (mul1r a)
+    (mulrDl a) (mulrDr a) (mul0r) (mulr0).
+  Elpi hb.canonical A to_SemiRing_of_AddComoid.
 
-Elpi hb.end to_SemiRing_of_AddComoid.
+Elpi hb.end.
 
 (* End change *)
 
@@ -117,14 +118,12 @@ Elpi hb.declare_factory Ring_of_AddComoid A AddComoid.axioms.
 
   Variable a : axioms.
 
-  Definition to_AddAG_of_AddComoid : AddAG_of_AddComoid.axioms_ A :=
-    AddAG_of_AddComoid.Axioms _ (addNr a).
+  Definition to_AddAG_of_AddComoid := AddAG_of_AddComoid.Axioms_ A _ (addNr a).
   Elpi hb.canonical A to_AddAG_of_AddComoid.
 
-  Definition to_Ring_of_AddAG : Ring_of_AddAG.axioms_ A :=
-    Ring_of_AddAG.Axioms _ _ (mulrA a) (mul1r a) (mulr1 a) (mulrDl a) (mulrDr a).
-
-Elpi hb.end to_AddAG_of_AddComoid to_Ring_of_AddAG.
+  Definition to_Ring_of_AddAG := Ring_of_AddAG.Axioms_ A _ _ (mulrA a) (mul1r a) (mulr1 a) (mulrDl a) (mulrDr a).
+  Elpi hb.canonical A to_Ring_of_AddAG.
+Elpi hb.end.
 
 Elpi hb.declare_factory Ring_of_TYPE A.
   Record axioms := Axioms {
@@ -145,14 +144,15 @@ Elpi hb.declare_factory Ring_of_TYPE A.
   }.
 
   Variable a : axioms.
-  Definition to_AddComoid_of_TYPE : AddComoid_of_TYPE.axioms_ A :=
+  Definition to_AddComoid_of_TYPE :=
     AddComoid_of_TYPE.Axioms (zero a) (add a) (addrA _) (addrC _) (add0r _).
   Elpi hb.canonical A to_AddComoid_of_TYPE.
 
-  Definition to_Ring_of_AddComoid : Ring_of_AddComoid.axioms_ A :=
+  Definition to_Ring_of_AddComoid :=
     Ring_of_AddComoid.Axioms _ _ _ (addNr _) (mulrA _) (mul1r _)
       (mulr1 _) (mulrDl _) (mulrDr _).
-Elpi hb.end to_AddComoid_of_TYPE to_Ring_of_AddComoid.
+  Elpi hb.canonical A to_Ring_of_AddComoid.
+Elpi hb.end.
 
 Elpi hb.structure Ring Ring_of_TYPE.axioms.
 
@@ -190,7 +190,7 @@ End Theory.
 
 (* Instance *)
 
-Definition Z_ring_axioms : Ring_of_TYPE.axioms_ Z :=
+Definition Z_ring_axioms :=
   Ring_of_TYPE.Axioms 0%Z 1%Z Z.add Z.opp Z.mul
     Z.add_assoc Z.add_comm Z.add_0_l Z.add_opp_diag_l
     Z.mul_assoc Z.mul_1_l Z.mul_1_r

--- a/demo1/stage4.v
+++ b/demo1/stage4.v
@@ -42,14 +42,14 @@ Elpi hb.declare_factory AddComoid_of_TYPE A.
   Fact addr0 : right_id (zero a) (add a).
   Proof. by move=> x; rewrite addrC add0r. Qed.
 
-  Definition to_AddMonoid_of_TYPE : AddMonoid_of_TYPE.axioms_ A :=
-    AddMonoid_of_TYPE.Axioms (zero a) (add a) (addrA a) (add0r a) addr0.
+  Definition to_AddMonoid_of_TYPE :=
+    AddMonoid_of_TYPE.Axioms_ A (zero a) (add a) (addrA a) (add0r a) addr0.
   Elpi hb.canonical A to_AddMonoid_of_TYPE.
 
-  Definition to_AddComoid_of_AddMonoid : AddComoid_of_AddMonoid.axioms_ A :=
-    AddComoid_of_AddMonoid.Axioms (addrC a : commutative AddMonoid.Exports.add).
-
-Elpi hb.end to_AddMonoid_of_TYPE to_AddComoid_of_AddMonoid.
+  Definition to_AddComoid_of_AddMonoid :=
+    AddComoid_of_AddMonoid.Axioms_ A (addrC a : commutative AddMonoid.Exports.add).
+  Elpi hb.canonical A to_AddComoid_of_AddMonoid.
+Elpi hb.end.
 Elpi hb.structure AddComoid AddComoid_of_TYPE.axioms.
 
 (* End change *)
@@ -73,13 +73,14 @@ Elpi hb.declare_factory AddAG_of_TYPE A.
 
   Variable a : axioms.
 
-  Definition to_AddComoid_of_TYPE : AddComoid_of_TYPE.axioms_ A :=
-    AddComoid_of_TYPE.Axioms (zero a) (add a) (addrA _) (addrC _) (add0r _).
+  Definition to_AddComoid_of_TYPE :=
+    AddComoid_of_TYPE.Axioms_ A (zero a) (add a) (addrA _) (addrC _) (add0r _).
   Elpi hb.canonical A to_AddComoid_of_TYPE.
 
-  Definition to_AddAG_of_AddComoid : AddAG_of_AddComoid.axioms_ A :=
-    AddAG_of_AddComoid.Axioms _ (addNr a).
-Elpi hb.end to_AddComoid_of_TYPE to_AddAG_of_AddComoid.
+  Definition to_AddAG_of_AddComoid :=
+    AddAG_of_AddComoid.Axioms_ A _ (addNr a).
+  Elpi hb.canonical A to_AddAG_of_AddComoid.
+Elpi hb.end.
 Elpi hb.structure AddAG AddAG_of_TYPE.axioms.
 
 Elpi hb.declare_mixin SemiRing_of_AddComoid A AddComoid.axioms.
@@ -124,11 +125,11 @@ Elpi hb.declare_factory Ring_of_AddAG A AddAG.axioms.
   by rewrite -mulrDr add0r addrC addNr.
   Qed.
 
-  Definition to_SemiRing_of_AddComoid : SemiRing_of_AddComoid.axioms_ A :=
-    SemiRing_of_AddComoid.Axioms _ (mul a) (mulrA a) (mulr1 a) (mul1r a)
+  Definition to_SemiRing_of_AddComoid :=
+    SemiRing_of_AddComoid.Axioms_ A _ (mul a) (mulrA a) (mulr1 a) (mul1r a)
       (mulrDl a) (mulrDr a) (mul0r) (mulr0).
-
-Elpi hb.end to_SemiRing_of_AddComoid.
+  Elpi hb.canonical A to_SemiRing_of_AddComoid.
+Elpi hb.end.
 
 Elpi hb.declare_factory Ring_of_AddComoid A AddComoid.axioms.
   Record axioms := Axioms {
@@ -145,14 +146,14 @@ Elpi hb.declare_factory Ring_of_AddComoid A AddComoid.axioms.
 
   Variable a : axioms.
 
-  Definition to_AddAG_of_AddComoid : AddAG_of_AddComoid.axioms_ A :=
-    AddAG_of_AddComoid.Axioms _ (addNr a).
+  Definition to_AddAG_of_AddComoid :=
+    AddAG_of_AddComoid.Axioms_ A _ (addNr a).
   Elpi hb.canonical A to_AddAG_of_AddComoid.
 
-  Definition to_Ring_of_AddAG : Ring_of_AddAG.axioms_ A :=
-    Ring_of_AddAG.Axioms _ _ (mulrA a) (mul1r a) (mulr1 a) (mulrDl a) (mulrDr a).
-
-Elpi hb.end to_AddAG_of_AddComoid to_Ring_of_AddAG.
+  Definition to_Ring_of_AddAG :=
+    Ring_of_AddAG.Axioms_ A _ _ (mulrA a) (mul1r a) (mulr1 a) (mulrDl a) (mulrDr a).
+  Elpi hb.canonical A to_Ring_of_AddAG.
+Elpi hb.end.
 
 Elpi hb.declare_factory Ring_of_TYPE A.
   Record axioms := Axioms {
@@ -173,14 +174,14 @@ Elpi hb.declare_factory Ring_of_TYPE A.
   }.
 
   Variable a : axioms.
-  Definition to_AddComoid_of_TYPE : AddComoid_of_TYPE.axioms_ A :=
-    AddComoid_of_TYPE.Axioms (zero a) (add a) (addrA _) (addrC _) (add0r _).
+  Definition to_AddComoid_of_TYPE := AddComoid_of_TYPE.Axioms_ A
+    (zero a) (add a) (addrA _) (addrC _) (add0r _).
   Elpi hb.canonical A to_AddComoid_of_TYPE.
 
-  Definition to_Ring_of_AddComoid : Ring_of_AddComoid.axioms_ A :=
-    Ring_of_AddComoid.Axioms _ _ _ (addNr _) (mulrA _) (mul1r _)
-      (mulr1 _) (mulrDl _) (mulrDr _).
-Elpi hb.end to_AddComoid_of_TYPE to_Ring_of_AddComoid.
+  Definition to_Ring_of_AddComoid := Ring_of_AddComoid.Axioms_ A _ _ _
+    (addNr _) (mulrA _) (mul1r _) (mulr1 _) (mulrDl _) (mulrDr _).
+  Elpi hb.canonical A to_Ring_of_AddComoid.
+Elpi hb.end.
 
 Elpi hb.structure Ring Ring_of_TYPE.axioms.
 
@@ -219,8 +220,8 @@ End Theory.
 
 (* Instance *)
 
-Definition Z_ring_axioms : Ring_of_TYPE.axioms_ Z :=
-  Ring_of_TYPE.Axioms 0%Z 1%Z Z.add Z.opp Z.mul
+Definition Z_ring_axioms :=
+  Ring_of_TYPE.Axioms_ Z 0%Z 1%Z Z.add Z.opp Z.mul
     Z.add_assoc Z.add_comm Z.add_0_l Z.add_opp_diag_l
     Z.mul_assoc Z.mul_1_l Z.mul_1_r
     Z.mul_add_distr_r Z.mul_add_distr_l.

--- a/demo1/stage5.v
+++ b/demo1/stage5.v
@@ -41,14 +41,14 @@ Elpi hb.declare_factory AddComoid_of_TYPE A.
   Fact addr0 : right_id (zero a) (add a).
   Proof. by move=> x; rewrite addrC add0r. Qed.
 
-  Definition to_AddMonoid_of_TYPE : AddMonoid_of_TYPE.axioms_ A :=
-    AddMonoid_of_TYPE.Axioms (zero a) (add a) (addrA a) (add0r a) addr0.
-  Elpi hb.canonical A to_AddMonoid_of_TYPE.
+  Definition to_AddMonoid := AddMonoid_of_TYPE.Axioms_ A
+    (zero a) (add a) (addrA a) (add0r a) addr0.
+  Elpi hb.canonical A to_AddMonoid.
 
-  Definition to_AddComoid_of_AddMonoid : AddComoid_of_AddMonoid.axioms_ A :=
-    AddComoid_of_AddMonoid.Axioms (addrC a : commutative AddMonoid.Exports.add).
-
-Elpi hb.end to_AddMonoid_of_TYPE to_AddComoid_of_AddMonoid.
+  Definition to_AddComoid := AddComoid_of_AddMonoid.Axioms_ A
+    (addrC a : commutative AddMonoid.Exports.add).
+  Elpi hb.canonical A to_AddComoid.
+Elpi hb.end.
 Elpi hb.structure AddComoid AddComoid_of_TYPE.axioms.
 
 Elpi hb.declare_mixin AddAG_of_AddComoid A AddComoid.axioms.
@@ -70,13 +70,14 @@ Elpi hb.declare_factory AddAG_of_TYPE A.
 
   Variable a : axioms.
 
-  Definition to_AddComoid_of_TYPE : AddComoid_of_TYPE.axioms_ A :=
-    AddComoid_of_TYPE.Axioms (zero a) (add a) (addrA _) (addrC _) (add0r _).
+  Definition to_AddComoid_of_TYPE := AddComoid_of_TYPE.Axioms_ A
+    (zero a) (add a) (addrA _) (addrC _) (add0r _).
   Elpi hb.canonical A to_AddComoid_of_TYPE.
 
-  Definition to_AddAG_of_AddComoid : AddAG_of_AddComoid.axioms_ A :=
-    AddAG_of_AddComoid.Axioms _ (addNr a).
-Elpi hb.end to_AddComoid_of_TYPE to_AddAG_of_AddComoid.
+  Definition to_AddAG_of_AddComoid := AddAG_of_AddComoid.Axioms_ A _ (addNr a).
+  Elpi hb.canonical A to_AddAG_of_AddComoid.
+
+Elpi hb.end.
 Elpi hb.structure AddAG AddAG_of_TYPE.axioms.
 
 (* Begin changes *)
@@ -102,8 +103,10 @@ Elpi hb.declare_factory SemiRing_of_AddComoid A AddComoid.axioms.
   Definition axioms := BiNearRing_of_AddMonoid.axioms_ A.
   Definition Axioms := @BiNearRing_of_AddMonoid.Axioms.
   Variables (a : axioms).
-  Definition to_BiNearRing_of_AddMonoid : BiNearRing_of_AddMonoid.axioms_ A := a.
-Elpi hb.end to_BiNearRing_of_AddMonoid.
+  Definition to_BiNearRing_of_AddMonoid :
+     BiNearRing_of_AddMonoid.axioms_ A := a.
+  Elpi hb.canonical A to_BiNearRing_of_AddMonoid.
+Elpi hb.end.
 
 (* End changes *)
 
@@ -136,11 +139,12 @@ Elpi hb.declare_factory Ring_of_AddAG A AddAG.axioms.
   by rewrite -mulrDr add0r addrC addNr.
   Qed.
 
-  Definition to_SemiRing_of_AddComoid : SemiRing_of_AddComoid.axioms_ A :=
-    SemiRing_of_AddComoid.Axioms _ (mul a) (mulrA a) (mulr1 a) (mul1r a)
-      (mulrDl a) (mulrDr a) (mul0r) (mulr0).
+  Definition to_SemiRing_of_AddComoid := SemiRing_of_AddComoid.Axioms_ A
+    _ (mul a) (mulrA a) (mulr1 a) (mul1r a)
+    (mulrDl a) (mulrDr a) (mul0r) (mulr0).
+  Elpi hb.canonical A to_SemiRing_of_AddComoid.
 
-Elpi hb.end to_SemiRing_of_AddComoid.
+Elpi hb.end.
 
 Elpi hb.declare_factory Ring_of_AddComoid A AddComoid.axioms.
   Record axioms := Axioms {
@@ -157,14 +161,14 @@ Elpi hb.declare_factory Ring_of_AddComoid A AddComoid.axioms.
 
   Variable a : axioms.
 
-  Definition to_AddAG_of_AddComoid : AddAG_of_AddComoid.axioms_ A :=
-    AddAG_of_AddComoid.Axioms _ (addNr a).
+  Definition to_AddAG_of_AddComoid := AddAG_of_AddComoid.Axioms_ A _ (addNr a).
   Elpi hb.canonical A to_AddAG_of_AddComoid.
 
-  Definition to_Ring_of_AddAG : Ring_of_AddAG.axioms_ A :=
-    Ring_of_AddAG.Axioms _ _ (mulrA a) (mul1r a) (mulr1 a) (mulrDl a) (mulrDr a).
+  Definition to_Ring_of_AddAG := Ring_of_AddAG.Axioms_ A
+    _ _ (mulrA a) (mul1r a) (mulr1 a) (mulrDl a) (mulrDr a).
+  Elpi hb.canonical A to_Ring_of_AddAG.
 
-Elpi hb.end to_AddAG_of_AddComoid to_Ring_of_AddAG.
+Elpi hb.end.
 
 Elpi hb.declare_factory Ring_of_TYPE A.
   Record axioms := Axioms {
@@ -185,14 +189,14 @@ Elpi hb.declare_factory Ring_of_TYPE A.
   }.
 
   Variable a : axioms.
-  Definition to_AddComoid_of_TYPE : AddComoid_of_TYPE.axioms_ A :=
-    AddComoid_of_TYPE.Axioms (zero a) (add a) (addrA _) (addrC _) (add0r _).
+  Definition to_AddComoid_of_TYPE := AddComoid_of_TYPE.Axioms_ A
+    (zero a) (add a) (addrA _) (addrC _) (add0r _).
   Elpi hb.canonical A to_AddComoid_of_TYPE.
 
-  Definition to_Ring_of_AddComoid : Ring_of_AddComoid.axioms_ A :=
-    Ring_of_AddComoid.Axioms _ _ _ (addNr _) (mulrA _) (mul1r _)
-      (mulr1 _) (mulrDl _) (mulrDr _).
-Elpi hb.end to_AddComoid_of_TYPE to_Ring_of_AddComoid.
+  Definition to_Ring_of_AddComoid := Ring_of_AddComoid.Axioms_ A
+    _ _ _ (addNr _) (mulrA _) (mul1r _) (mulr1 _) (mulrDl _) (mulrDr _).
+  Elpi hb.canonical A to_Ring_of_AddComoid.
+Elpi hb.end.
 
 Elpi hb.structure Ring Ring_of_TYPE.axioms.
 
@@ -231,8 +235,8 @@ End Theory.
 
 (* Instance *)
 
-Definition Z_ring_axioms : Ring_of_TYPE.axioms_ Z :=
-  Ring_of_TYPE.Axioms 0%Z 1%Z Z.add Z.opp Z.mul
+Definition Z_ring_axioms :=
+  Ring_of_TYPE.Axioms_ Z 0%Z 1%Z Z.add Z.opp Z.mul
     Z.add_assoc Z.add_comm Z.add_0_l Z.add_opp_diag_l
     Z.mul_assoc Z.mul_1_l Z.mul_1_r
     Z.mul_add_distr_r Z.mul_add_distr_l.

--- a/hb.elpi
+++ b/hb.elpi
@@ -166,7 +166,8 @@ instanciate-mixin T M (fun _ Tm F) (F X) :-
   safe-dest-app Tm (global TmGR) _,
   factory-alias TmGR M, !,
   mixin-for T M X, !.
-instanciate-mixin T M (fun N T F) (fun N T FX) :- !, pi m\ instanciate-mixin T M (F m) (FX m).
+instanciate-mixin T M (fun N Ty F) (fun N Ty FX) :- !,
+  pi m\ instanciate-mixin T M (F m) (FX m).
 instanciate-mixin _ _ F F.
 
 % [mterm->term T MF TFX] assumes that MF is a mterm
@@ -810,8 +811,11 @@ map11 XS [] _ F _ ZS :- !, std.map XS F ZS.
 map11 [] YS _ _ F ZS :- !, std.map YS F ZS.
 map11 [X|XS] [Y|YS] F G H [Z|ZS] :- !, F X Y Z, map11 XS YS F G H ZS.
 
-pred main-end-declare i:list term.
-main-end-declare TS :- std.do! [
+pred extract-local-factory i:prop, o:term.
+extract-local-factory (local-factory F) F.
+
+pred main-end-declare.
+main-end-declare :- std.do! [
   current-decl Decl,
   std.findall (mixin-src T_ M_ X_) AllPostulatedMixins,
   std.map AllPostulatedMixins mixin-src-name ML,
@@ -820,8 +824,13 @@ main-end-declare TS :- std.do! [
 
   coq.env.end-section,
 
-  if (Decl = mixin-decl) (TS = [], !, main-mixin-requires GR ML Props, Clauses = []) (
+  mk-phant-mixins (global GRK) PhGRK,
+  mk-phant-abbrev "Axioms_" PhGRK _,
+
+  if (Decl = mixin-decl) (!, main-mixin-requires GR ML Props, Clauses = []) (
     Decl = factory-decl, !,
+    std.findall (local-factory F_) LFIL,
+    std.map LFIL extract-local-factory TS,
     main-factory-requires GR ML Props,
     Props => std.fold TS [] main-declare-factory-fun Clauses
   ),

--- a/hb.v
+++ b/hb.v
@@ -105,6 +105,9 @@ kind declaration type.
 type mixin-decl declaration.
 type factory-decl declaration.
 pred current-decl o:declaration.
+
+pred local-factory o:term.
+
 }}.
 
 Elpi Command debug.
@@ -213,8 +216,8 @@ Elpi Command hb.end.
 Elpi Accumulate File "hb.elpi".
 Elpi Accumulate Db hb.db.
 Elpi Accumulate lp:{{
-main FS :- std.map FS argument->term TS, !,  main-end-declare TS.
-main _ :- coq.error "Usage: hb.end (\"mixin\"|\"factory\" <FactoryGRs>*)".
+main [] :- main-end-declare.
+main _ :- coq.error "Usage: hb.end.".
 }}.
 Elpi Typecheck.
 
@@ -233,6 +236,7 @@ Elpi Accumulate File "hb.elpi".
 Elpi Accumulate Db hb.db.
 Elpi Accumulate lp:{{
 main [S|FIS] :- std.map [S|FIS] argument->term [T|FIL], !, std.do! [
+  std.forall FIL (f\ acc current (clause _ _ (local-factory f))),
   std.map FIL (mixin-srcs T) MSLL,
   canonical-mixins T CMSL,
   std.flatten [CMSL|MSLL] MSL,


### PR DESCRIPTION
- factory declaration are now gathered from instances
- when we have an Axiom_ A constructor, no need to put the axiom_ A type
- Qc is a toplogical group, and is "automatically" uniform
- fixed a bug in instanciate-mixin