### PR TITLE
[feature] parameters in structures

### DIFF
--- a/.travis/docker-install.sh
+++ b/.travis/docker-install.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
-
 set -e
-
 docker pull coqorg/coq:${COQ}
 docker run -d -i --init --name=COQ -v ${TRAVIS_BUILD_DIR}:/home/coq/${CONTRIB_NAME} -w /home/coq/${CONTRIB_NAME} coqorg/coq:${COQ}
 docker exec COQ /bin/bash --login -c "

--- a/.travis/docker-test.sh
+++ b/.travis/docker-test.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
-
 set -e
-
 echo -e "${ANSI_YELLOW}Building ${CONTRIB_NAME}...${ANSI_RESET}" && echo -en 'travis_fold:start:script\\r'
 
 docker exec COQ /bin/bash --login -c "

--- a/_CoqProject
+++ b/_CoqProject
@@ -29,6 +29,8 @@ demo3/test_0_0.v
 demo3/test_1_0.v
 demo3/test_2_0.v
 
+demo4/hierarchy_0.v
+
 FSCD2020_material/V1.v
 FSCD2020_material/V2.v
 FSCD2020_material/V3.v

--- a/demo4/hierarchy_0.v
+++ b/demo4/hierarchy_0.v
@@ -9,6 +9,15 @@ HB.structure Definition s1 T := { A of m1 T A }.
 Check inhab.
   (* inhab : forall (T : Type) (A : s1.type T), s1.sort A *)
 
+HB.instance Definition nat_m1 := m1.Build bool nat 7 false.
+Check (refl_equal _ : @inhab _ _ = 7).
+
+Section Foo.
+Variable A : Type.
+HB.instance Definition list_m1 := m1.Build (option A) (list nat) (cons 7 nil) None.
+End Foo.
+Check (refl_equal _ : @inhab _ _ = (cons 7 nil)).
+
 HB.mixin Record m2 (T : Type) (A : Type) of m1 T A := {
   inj : T -> A;
 }.

--- a/demo4/hierarchy_0.v
+++ b/demo4/hierarchy_0.v
@@ -12,10 +12,7 @@ Check inhab.
 HB.instance Definition nat_m1 := m1.Build bool nat 7 false.
 Check (refl_equal _ : @inhab _ _ = 7).
 
-Section Foo.
-Variable A : Type.
-HB.instance Definition list_m1 := m1.Build (option A) (list nat) (cons 7 nil) None.
-End Foo.
+HB.instance Definition list_m1 A := m1.Build (option A) (list nat) (cons 7 nil) None.
 Check (refl_equal _ : @inhab _ _ = (cons 7 nil)).
 
 HB.mixin Record m2 (T : Type) (A : Type) of m1 T A := {

--- a/demo4/hierarchy_0.v
+++ b/demo4/hierarchy_0.v
@@ -1,0 +1,21 @@
+From HB Require Import structures.
+
+HB.mixin Record m1 (T : Type) (A : Type) := {
+  inhab : A;
+  inhab_param : T;
+}.
+HB.structure Definition s1 T := { A of m1 T A }.
+
+Check inhab.
+  (* inhab : forall (T : Type) (A : s1.type T), s1.sort A *)
+
+HB.mixin Record m2 (T : Type) (A : Type) of m1 T A := {
+  inj : T -> A;
+}.
+
+HB.structure Definition s2 T :=
+  { A of m1 T A & m2 T A }.
+
+Check fun X : s2.type nat => inhab : X.
+Check fun X : s2.type nat => inj : nat -> X.
+About s2_to_s1.

--- a/hb.elpi
+++ b/hb.elpi
@@ -239,11 +239,10 @@ w-params.nparams (w-params.nil _ _ _) 0.
 % [w-params.then AwP Nil Cons Pred Out] states that Out has shape
 %   Cons `x_1` T_1 p_1 \ .. \ Nil `T` {{Type}} t \ Body
 %   where the-type [p_1 .. p_n] T => Pred Body
-pred the-type o:list term, o:term.
 pred w-params.then i:w-params A,
    i:(name -> term -> (term -> B) -> C -> prop),
    i:(name -> term -> (term -> C) -> C -> prop),
-   i:(A -> B -> prop),
+   i:(list term -> term -> A -> B -> prop),
    o:C.
 w-params.then L Nil Cons P O :- w-params.then.params L Nil Cons [] P O.
 
@@ -251,17 +250,18 @@ pred w-params.then.params i:w-params A,
    i:(name -> term -> (term -> B) -> C -> prop),
    i:(name -> term -> (term -> C) -> C -> prop),
    i:list term, % accumulator
-   i:(A -> B -> prop), o:C.
+   i:(list term -> term -> A -> B -> prop), o:C.
 w-params.then.params (w-params.cons N PTy ML) Nil Cons RevParams Pred Out :-
   @pi-decl N PTy p\
     w-params.then.params (ML p) Nil Cons [p|RevParams] Pred (Body p),
     Cons N PTy Body Out.
 w-params.then.params (w-params.nil NT TTy ML) Nil _ RevParams Pred Out :-
   std.rev RevParams Params,
-  @pi-decl NT TTy t\ the-type Params t => Pred (ML t) (Body t),
+  @pi-decl NT TTy t\
+    Pred Params t (ML t) (Body t),
     Nil NT TTy Body Out.
 
-pred w-params.map i:w-params A, i:(A -> B -> prop), o:w-params B.
+pred w-params.map i:w-params A, i:(list term -> term -> A -> B -> prop), o:w-params B.
 w-params.map AL F BL :- w-params.then AL (mk3 w-params.nil) (mk3 w-params.cons) F BL.
 
 % on the fly abstraction
@@ -273,7 +273,7 @@ bind-cons N T X V (w-params.cons N T A) :- V = A X.
 
 % Specific to list-w-params
 pred list-w-params_list i:list-w-params A, o:list A.
-list-w-params_list AwP R :- w-params.then AwP ignore ignore (x\ std.map x triple_1) R.
+list-w-params_list AwP R :- w-params.then AwP ignore ignore (p\ t\ x\ std.map x triple_1) R.
 
 pred list-w-params.append i:list-w-params A, i:list-w-params A, o:list-w-params A.
 list-w-params.append (w-params.nil N T ML1) (w-params.nil N T ML2) (w-params.nil N T ML) :-
@@ -324,7 +324,7 @@ distribute-w-params (w-params.nil N T F) L :-
 
 % Specific to one-w-params
 pred w-params_1 i:one-w-params A, o:A.
-w-params_1 X Y :- w-params.then X ignore ignore triple_1 Y.
+w-params_1 X Y :- w-params.then X ignore ignore (p\ t\ triple_1) Y.
 
 %%%%%%%%% HB database %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -371,12 +371,12 @@ factory-provides FactoryAlias MLwP :- std.do! [
   w-params.map RMLwP (factory-provides.base Factory) MLwP
 ].
 
-pred factory-provides.base i:factoryname, i:list (w-args mixinname), o:list (w-args mixinname).
-factory-provides.base Factory _RMLwP MLwP :- std.do! [
+pred factory-provides.base i:factoryname, i:list term, i: term,
+  i:list (w-args mixinname), o:list (w-args mixinname).
+factory-provides.base Factory Params T _RMLwP MLwP :- std.do! [
   std.findall (from Factory T_ F_) All,
   std.map All from_mixin ML,
   std.map All from_builder BL,
-  the-type Params T,
   std.map2 BL ML (factory-provides.one Params T) MLwP,
 ].
 
@@ -405,7 +405,7 @@ extract-conclusion-params T R :- whd1 T T1, !, extract-conclusion-params T1 R.
 pred factories-provide i:list-w-params factoryname, o:list-w-params mixinname.
 factories-provide FLwP MLwP :-
   list-w-params.flatten-map FLwP factory-provides UnsortedMLwP,
-  w-params.map UnsortedMLwP toposort-mixins MLwP.
+  w-params.map UnsortedMLwP (p\t\ toposort-mixins) MLwP.
 
 % Mixins can be topologically sorted according to their dependencies
 pred toposort-mixins.mk-mixin-edge i:prop, o:list (pair mixinname mixinname).
@@ -838,9 +838,9 @@ under-mixins.then [triple M Args T|ML] Mixin Pred Out :- std.do! [
 % where  MLwP contains M_0, .., M_n (under p_1 .. p_k)
 %   and  Body is such that [..,mixin-src T M_i m_i,..] => Pred Body
 %   and  ..p.. is a list of terms built using p_1 .. p_k and T
-pred mk-mixin-fun.then i:list-w-params mixinname, i:(term -> prop), o:term.
+pred mk-mixin-fun.then i:list-w-params mixinname, i:(list term -> term -> term -> prop), o:term.
 mk-mixin-fun.then L P Out :- !,
-  w-params.then L mk-fun mk-fun (ml\ out\ under-mixins.then ml mk-fun P out) Out.
+  w-params.then L mk-fun mk-fun (p\ t\ ml\ out\ under-mixins.then ml mk-fun (P p t) out) Out.
 
 % A *pack* notation can be easiliy produced from a phant-term using
 % [mk-phant-abbrev N PT C], which states that C is a new constant
@@ -1051,9 +1051,8 @@ main-mixin-requires Str GR GRFS [From|PO] SN :- !, std.do! [
   % register factory
   PO => std.do! [
     mk-mixin-fun.then {factory-requires GR}
-      (body\ sigma MTy Params T\
-        the-type Params T,
-        mgref->term Params T GR MTy,
+      (params\ t\ body\ sigma MTy\
+        mgref->term params t GR MTy,
         body = fun `x` MTy x\x)
       IDBody
   ],
@@ -1086,18 +1085,18 @@ main-declare-context TheType TheParams GRFSwP MSL :-  std.do! [
   std.forall MSL (ms\ acc current (clause _ _ ms)),
 ].
 
-% [factory-comp TheType SrcFactory MB MiddleFactory TgtMixin B1] synthesizes
+% [factory-comp SrcFactory MB MiddleFactory TgtMixin B1] synthesizes
 %   B1 = MB o B
 % where MB is the builder from MiddleFactory to TgtMixin and
 % B is a builder from SrcFactory to MiddleFactory
-pred factory-comp i:list mixinname, i:factoryname, i:term, i:factoryname, i:mixinname, o:term.
-factory-comp ML SrcFactory B MiddleFactory TgtMixin Comp :-
-  the-type TheParams TheType,
-  mgref->term TheParams TheType SrcFactory Src,
-  MB = mterm TheParams TheType ML B,
+pred factory-comp i:list mixinname, i:factoryname, i:term, i:factoryname,
+  i:mixinname, i:list term, i:term, o:term.
+factory-comp ML SrcFactory B MiddleFactory TgtMixin Params Type Comp :-
+  mgref->term Params Type SrcFactory Src,
+  MB = mterm Params Type ML B,
   Comp = {{
     fun src : lp:Src => lp:{{
-      {under-mixin-src-from-factory.then TheType {{src}}
+      {under-mixin-src-from-factory.then Type {{src}}
         (factory-comp-body {{src}} MB MiddleFactory TgtMixin)} }}
   }}.
 
@@ -1157,7 +1156,7 @@ export Module :- !,
   acc current (clause _ _ (to-export Module)).
 
 pred mk-mixin-fun i:list-w-params mixinname, i:term, o:term.
-mk-mixin-fun ML X MLX :- mk-mixin-fun.then ML (body\ body = X) MLX.
+mk-mixin-fun ML X MLX :- mk-mixin-fun.then ML (p\ t\ body\ body = X) MLX.
 
 % const Po : forall p1 .. pm T m1 .. mn, Extra  (Eg Extra = forall x y, x + y = y + z)
 % const C : forall p1 .. pm s, Extra
@@ -1178,8 +1177,8 @@ clean-op-ty [exported-op _ Po C|Ops] S T1 T2 :-
   clean-op-ty Ops S T1 T2.
 
 pred operation-body-and-ty i:list prop, i:constant, i:term, i:term, i:term,
-  i:w-args A, o:pair term term.
-operation-body-and-ty EXI Poperation Struct Psort Pclass (triple _ Params _) (pr Bo Ty) :- std.do! [
+  i:list term, i:term, i:w-args A, o:pair term term.
+operation-body-and-ty EXI Poperation Struct Psort Pclass Params _T (triple _ Params _) (pr Bo Ty) :- std.do! [
   mk-app Struct Params StructType,
   mk-app Psort Params PsortP,
   mk-app Pclass Params PclassP,
@@ -1190,7 +1189,7 @@ operation-body-and-ty EXI Poperation Struct Psort Pclass (triple _ Params _) (pr
       mk-app PclassP [s] Class,
       under-mixin-src-from-factory.do! Carrier Class [
         % just in case..
-        the-type Params Carrier => mgref->term Params Carrier (const Poperation) (Body s),
+        mgref->term Params Carrier (const Poperation) (Body s),
         std.assert-ok! (coq.typecheck (Body s) (DirtyTy s)) "export-1-operation: Body illtyped",
         clean-op-ty EXI s (DirtyTy s) (BodyTy s),
       ],
@@ -1252,10 +1251,10 @@ pred mk-coe-class-body
   i:factoryname, % From class
   i:factoryname, % To class
   i:list-w-params mixinname, % To mixins
+  i:list term, i:term, % Params, T
   i:list (w-args mixinname),
   o:term.
-mk-coe-class-body FC TC TMLwP _ CoeBody :- std.do! [
-  the-type Params T,
+mk-coe-class-body FC TC TMLwP Params T _ CoeBody :- std.do! [
   mk-app (global FC) Params ClassKP,
   mk-app ClassKP [T] Class,
 
@@ -1281,10 +1280,11 @@ pred mk-coe-structure-body
   i:term, % class coercion
   i:term, % sort projection
   i:term, % class projection
+  i:list term, i:term, % Params, T
   i:list (w-args mixinname),
   o:term.
-mk-coe-structure-body StructureF StructureT TC Coercion SortProjection ClassProjection _ SCoeBody :- std.do! [
-  the-type Params _T,
+mk-coe-structure-body StructureF StructureT TC Coercion SortProjection ClassProjection
+    Params _T _ SCoeBody :- std.do! [
   mk-app StructureF Params StructureP,
 
   factory-nparams TC NHoles,
@@ -1390,17 +1390,15 @@ synthesize-fields T  [triple M Args _|ML] (field _ Name MTy Fields) :- std.do! [
   @pi-decl `m` MTy m\ mixin-src T M m => synthesize-fields T ML (Fields m)
 ].
 
-pred synthesize-fields.body i:list (w-args mixinname), o:indt-decl.
-synthesize-fields.body ML (record "axioms" {{ Type }} "Class" FS) :-
-  the-type _ T,
+pred synthesize-fields.body i:list term, i:term, i:list (w-args mixinname), o:indt-decl.
+synthesize-fields.body _Params T ML (record "axioms" {{ Type }} "Class" FS) :-
   synthesize-fields T ML FS.
 
 pred mk-record+sort-field i:name, i:term, i:(term -> record-decl), o:indt-decl.
 mk-record+sort-field _ T F (record "type" {{ Type }} "Pack" (field _ "sort" T F)).
 
-pred mk-class-field i:classname, i:list (w-args mixinname), o:record-decl.
-mk-class-field ClassName _ (field _ "class" (app [global ClassName|Args]) _\end-record) :-
-  the-type Params T,
+pred mk-class-field i:classname, i:list term, i:term, i:list (w-args mixinname), o:record-decl.
+mk-class-field ClassName Params T _ (field _ "class" (app [global ClassName|Args]) _\end-record) :-
   std.append Params [T] Args.
 
 % Builds the axioms record and the factories from this class to each mixin
@@ -1461,7 +1459,7 @@ main-declare-structure Module GRFSwP ClosureCheck :- std.do! [
 
   list-w-params.flatten-map GRFSwP factory-requires RMLwP, % TODO: extract code from factories-provide
   list-w-params.append PMLwP RMLwP UnsortedMLwP,
-  w-params.map UnsortedMLwP toposort-mixins MLwP,
+  w-params.map UnsortedMLwP (p\t\ toposort-mixins) MLwP,
 
   list-w-params_list PMLwP PML,
   list-w-params_list MLwP ML,
@@ -1482,7 +1480,7 @@ main-declare-structure Module GRFSwP ClosureCheck :- std.do! [
   declare-class+structure MLwP
     ClassName Structure SortProjection ClassProjection Factories,
 
-  w-params.map MLwP (_\ mk-nil) NilwP,
+  w-params.map MLwP (_\_\_\ mk-nil) NilwP,
   ClassRequires = factory-requires (ClassName) NilwP,
   ClassAlias = (factory-alias->gref ClassName ClassName),
   CurrentClass = (class ClassName Structure MLwP),

--- a/hb.elpi
+++ b/hb.elpi
@@ -1060,6 +1060,19 @@ main-mixin-requires Str GR GRFS [From|PO] SN :- !, std.do! [
   From = from GR GR IDBody,
 ].
 
+% [postulate-arity A Acc T TS] postulates section variables
+% corresponding to parameters in arity A. TS is T applied
+% to all section variables (and hd-beta reduced). Acc should
+% be [] at call site.
+pred postulate-arity i:arity, i:list term, i:term, o:term.
+postulate-arity (parameter ID _ S A) Acc T T1 :-
+  coq.env.add-const ID _ S tt tt C,
+  Var = global (const C),
+  postulate-arity (A Var) [Var|Acc] T T1.
+postulate-arity (arity _) ArgsRev X T :-
+  hd-beta X {std.rev ArgsRev} X1 Stack1,
+  unwind X1 Stack1 T.
+
 % Given a type T, a fresh number N, and a mixin M it postulates
 % a variable "mN" inhabiting M applied to T and
 % all its dependencies, previously postulated and associated

--- a/hb.elpi
+++ b/hb.elpi
@@ -209,6 +209,20 @@ mk3 F X1 X2 X3 R :- constant R F [X1, X2, X3].
 pred mk4 i:any, i:any, i:any, i:any, i:any, o:any.
 mk4 F X1 X2 X3 X4 R :- constant R F [X1, X2, X3,X4].
 
+pred mk-fun i:name, i:term, i:(term -> term), o:term.
+mk-fun N Ty Body (fun N Ty Body).
+
+% generic argument to pass to w-params
+pred ignore i:name, i:term, i:(term -> A), o:A.
+ignore _ _ F X :- (pi x y\ F x = F y), X = F (sort prop).
+
+% combining body and type
+pred mk-fun-prod i:name, i:term, o:(term -> pair term term), o:pair term term.
+mk-fun-prod N Ty (x\ pr (Body x) (Type x)) (pr (fun N Ty Body) (prod N Ty Type)).
+
+pred mk-parameter i:implicit_kind, i:name, i:term, i:(term -> indt-decl), o:indt-decl.
+mk-parameter IK Name X F Decl :- !, Decl = parameter {coq.name->id Name} IK X F.
+
 %%%%%%%%%%%%%%%%%%%%%%
 % w-params interface %
 %%%%%%%%%%%%%%%%%%%%%%
@@ -221,14 +235,6 @@ apply-w-params _ _ _ _ :- coq.error "apply-w-params".
 pred w-params.nparams i:w-params A, o:int.
 w-params.nparams (w-params.cons _ _ F) N :- pi x\ w-params.nparams (F x) M, N is M + 1.
 w-params.nparams (w-params.nil _ _ _) 0.
-
-% generic argument to pass to w-params
-pred ignore i:name, i:term, i:(term -> A), o:A.
-ignore _ _ F X :- (pi x y\ F x = F y), X = F (sort prop).
-
-% combining body and type
-pred mk-fun-prod i:name, i:term, o:(term -> pair term term), o:pair term term.
-mk-fun-prod N Ty (x\ pr (Body x) (Type x)) (pr (fun N Ty Body) (prod N Ty Type)).
 
 % [w-params.then AwP Nil Cons Pred Out] states that Out has shape
 %   Cons `x_1` T_1 p_1 \ .. \ Nil `T` {{Type}} t \ Body
@@ -560,8 +566,9 @@ under-canonical-mixins-of.do! T P :-
 
 %%%%% mterm %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-% (mterm A) is always of the form [mterm ML F], which is a pair of
-% a list of mixins ML that should be substituted in F and a termF
+% mterm is always of the form [mterm P T ML F], which is the data of
+% parameters PL a type T, and a list of mixins ML and a term F
+% where F should applied to PL, T and instances of the mixins in ML
 kind mterm type.
 type mterm list term -> term -> list mixinname -> term -> mterm.
 
@@ -590,6 +597,44 @@ pred phant-fun i:phant-arg, i:term, i:(term -> phant-term), o:phant-term.
 phant-fun Arg Ty PhF (phant-term [Arg|ArgL] (fun N Ty F)) :-
   if (Arg = real-arg N) true (N = `_`),
   pi x\ PhF x = phant-term ArgL (F x).
+
+pred phant-fun-real i:name, i:term, i:(term -> phant-term), o:phant-term.
+phant-fun-real N T F Res :- !, phant-fun (real-arg N) T F Res.
+
+% [phant-fun-unify N X1 X2 PF PUF] states that PUF is a phant-term that
+% is starts with unifing X1 and X2 and then outputs PF.
+% N is ignored
+pred phant-fun-unify i:term, i:term, i:phant-term, o:phant-term.
+phant-fun-unify X1 X2 (phant-term AL F) (phant-term [unify-arg|AL] UF) :-
+  UF = {{fun u : lib:hb.unify lp:X1 lp:X2 lib:hb.none => lp:F}}.
+
+% [phant-fun-implicit N Ty PF PUF] states that PUF is a phant-term
+% which quantifies [PF x] over [x : Ty] (with name N)
+pred phant-fun-implicit i:name, i:term, i:(term -> phant-term), o:phant-term.
+phant-fun-implicit N Ty PF (phant-term [implicit-arg|AL] (fun N Ty F)) :- !,
+  pi t\ PF t = phant-term AL (F t).
+
+% [phant-fun-struct T SI PF PSF] states that PSF is a phant-term
+% which postulate a structure [s : SI] such that [T = sort s]
+% and then outputs [PF s]
+pred phant-fun-struct i:term, i:name, i:term, i:(term -> phant-term), o:phant-term.
+phant-fun-struct SI _Name T PF (phant-term [implicit-arg, unify-arg|AL] UF) :-
+  get-structure-sort-projection SI Sort,
+  pi s\ PF s = phant-term AL (F s),
+  UF = {{fun (s : lp:SI) (u : lib:hb.unify lp:T (lp:Sort s)
+    (lib:hb.some (lib:hb.pair "is not canonically a"%string lp:SI)))
+      => lp:(F s)}}.
+
+pred phant-fun-struct-and-class i:list term, i:term, i:classname,
+  i:name, i:term, i:(term -> phant-term), o:phant-term.
+phant-fun-struct-and-class Params T CN Name T PF Out :-
+  class-def (class CN SI _),
+  get-structure-constructor SI Params SK,
+  std.append Params [T] ClassArgs,
+  ClassTy = app [global CN | ClassArgs],
+  Out = {phant-fun-struct SI `s` T s\
+          {phant-fun-implicit Name ClassTy c\
+            {phant-fun-unify s (app [SK, T, c]) (PF c)}}}.
 
 pred print-ctx.
 print-ctx :- declare_constraint print-ctx [].
@@ -781,12 +826,10 @@ pred under-mixins.then i:list (w-args mixinname),
 under-mixins.then [] _ Pred Body :- !, Pred Body.
 under-mixins.then [triple M Args T|ML] Mixin Pred Out :- std.do! [
   mgref->term Args T M MTy,
-  @pi-decl `m` MTy m\ mixin-src T M m => under-mixins.then ML Mixin Pred (Body m),
-  Mixin `m` MTy Body Out
-  ].
-
-pred mk-fun i:name, i:term, i:(term -> term), o:term.
-mk-fun N Ty Body (fun N Ty Body).
+  @pi-decl `m` MTy m\ mixin-src T M m =>
+    under-mixins.then ML Mixin Pred (Body m),
+    Mixin `m` MTy Body Out
+].
 
 % [mk-mixin-fun.then MLwP Pred F] states that F has shape
 %   fun p_1 .. p_k T,
@@ -827,34 +870,12 @@ mk-phant-abbrev N (phant-term AL T) C Abbrev :- std.do! [
 % [acc-phant-abbrev Str GR PhGR Abbrev] makes a phantom abbreviation for F
 pred acc-phant-abbrev i:string, i:gref, o:gref, o:abbreviation.
 acc-phant-abbrev Str GR (const PhC) Abbrev :- !, std.do! [
-  mk-phant-mixins (global GR) PhGR,
+  mk-phant-term (global GR) PhGR,
   mk-phant-abbrev Str PhGR PhC Abbrev
 ].
 
-% [mk-phant-unify X1 X2 PF PUF] states that PUF is a phant-term that
-% is starts with unifing X1 and X2 and then outputs PF.
-pred mk-phant-unify i:term, i:term, i:phant-term, o:phant-term.
-mk-phant-unify X1 X2 (phant-term AL F) (phant-term [unify-arg|AL] UF) :-
-  UF = {{fun u : lib:hb.unify lp:X1 lp:X2 lib:hb.none => lp:F}}.
 
-% [mk-phant-implicit N Ty PF PUF] states that PUF is a phant-term
-% which quantifies [PF x] over [x : Ty] (with name N)
-pred mk-phant-implicit i:name, i:term, i:(term -> phant-term), o:phant-term.
-mk-phant-implicit N Ty PF (phant-term [implicit-arg|AL] (fun N Ty F)) :- !,
-  pi t\ PF t = phant-term AL (F t).
-
-% [mk-phant-struct T SI PF PSF] states that PSF is a phant-term
-% which postulate a structure [s : SI] such that [T = sort s]
-% and then outputs [PF s]
-pred mk-phant-struct i:term, i:term, i:(term -> phant-term), o:phant-term.
-mk-phant-struct T SI PF (phant-term [implicit-arg, unify-arg|AL] UF) :-
-  get-structure-sort-projection SI Sort,
-  (pi s\ PF s = phant-term AL (F s)),
-  UF = {{fun (s : lp:SI) (u : lib:hb.unify lp:T (lp:Sort s)
-    (lib:hb.some (lib:hb.pair "is not canonically a"%string lp:SI)))
-      => lp:(F s)}}.
-
-% [mk-phant-mixins F PF] states that if F = fun p1 .. p_k T m_0 .. m_n => _
+% [mk-phant-term F PF] states that if F = fun p1 .. p_k T m_0 .. m_n => _
 % then PF = phant-term
 %   [real-arg p_1, ... real-arg p_k,
 %    real-arg T,
@@ -874,7 +895,7 @@ mk-phant-struct T SI PF (phant-term [implicit-arg, unify-arg|AL] UF) :-
 %                [find m_k_0, .., m_k_nk | c_k ~ CK m_k_0 .. m_k_nk]
 
 % Cyril: FIX so that
-% [mk-phant-mixins F PF] states that
+% [mk-phant-term F PF] states that
 % if F = fun p1 .. p_k T m_0 .. m_n => _
 % then PF = phant-term
 %   [real-arg p_1, ... real-arg p_k, real-arg T, implicit-arg, .., implicit-arg,
@@ -902,65 +923,57 @@ mk-phant-struct T SI PF (phant-term [implicit-arg, unify-arg|AL] UF) :-
 %         [find m'_{i_k_0}, .., m'_{i_k_nk} | c_0 ~ CK m'_{i_k_0} .. m'_{i_k_nk}]
 %         fun of hb.unify m_{i_0_0} m'_{i_0_0} & ... & hb.unify m_{i_k_nk} m'_{i_k_nk} =>
 %       F p_1 ... p_k T m_i0_j0 .. m_il_jl}}
-pred mk-phant-mixins.class-mixins i:list term, i:term, i:classname, i:term,
+pred mk-phant-term.class-mixins i:list term, i:term, i:classname, i:term,
   i:list (w-args mixinname), i:phant-term, o:phant-term.
-mk-phant-mixins.class-mixins Params T CN C [] PF UPF :- !, std.do![
+mk-phant-term.class-mixins Params T CN C [] PF UPF :- !, std.do![
     get-class-constructor CN Params K, class-def (class CN _ CMLwP),
     list-w-params_list CMLwP CML,
     mterm->term (mterm Params T CML K) KCML,
-    mk-phant-unify C KCML PF UPF].
-mk-phant-mixins.class-mixins Params T CN C [triple M Args _|ML] (phant-term AL FMML) LamPFmmL :- !,
+    phant-fun-unify C KCML PF UPF].
+mk-phant-term.class-mixins Params T CN C [triple M Args _|ML] (phant-term AL FMML) LamPFmmL :- !,
     mgref->term Args T M MTy,
     (@pi-decl `m` MTy m\ mixin-src T M m => sigma FmML\
       instantiate-mixin T M FMML FmML,
-      mk-phant-mixins.class-mixins Params T CN C ML (phant-term AL FmML) (PFmmL m)),
-    mk-phant-implicit `m` MTy PFmmL LamPFmmL.
+      mk-phant-term.class-mixins Params T CN C ML (phant-term AL FmML) (PFmmL m)),
+    phant-fun-implicit `m` MTy PFmmL LamPFmmL.
 
-pred mk-phant-mixins.class i:term, i:classname, i:phant-term, o:phant-term.
-mk-phant-mixins.class T CN PF SCF :- !,
-  class-def (class CN SI CML),
-  get-structure-constructor SI [/*fixme params*/] SK,
-  mk-phant-mixins.class.aux T CN CML SI SK PF [] SCF.
+pred mk-phant-term.class i:term, i:classname, i:phant-term, o:phant-term.
+mk-phant-term.class T CN PF SCF :- !,
+  class-def (class CN _ CML),
+  mk-phant-term.class.aux T CN CML PF [] SCF.
 
-pred mk-phant-mixins.class.aux
-  i:term,
-  i:classname, i:list-w-params mixinname,
-  i:structure, i:term,
+pred mk-phant-term.class.aux
+  i:term, i:classname, i:list-w-params mixinname,
   i:phant-term, i:list term, o:phant-term.
-mk-phant-mixins.class.aux T CN (w-params.cons N Ty ML) SI SK PF RevParams Out :-
-  Out = {mk-phant-implicit N Ty p\
-          {mk-phant-mixins.class.aux T CN (ML p) SI SK PF [p|RevParams]}}.
-mk-phant-mixins.class.aux T CN (w-params.nil _ _ ML) SI SK PF RevParams Out :-
-  MLT = ML T,
-  std.rev [T|RevParams] ClassArgs,
-  ClassTy = app [global CN|ClassArgs],
-  Out = {mk-phant-struct T SI s\
-          {mk-phant-implicit `c` ClassTy c\
-            {mk-phant-unify s (app [SK | {std.append ClassArgs [c]} ])
-              {mk-phant-mixins.class-mixins {std.rev RevParams} T CN c MLT PF}}}}.
+mk-phant-term.class.aux T CN (w-params.cons N Ty ML) PF RevParams Out :-
+  Out = {phant-fun-implicit N Ty p\
+          {mk-phant-term.class.aux T CN (ML p) PF [p|RevParams]}}.
+mk-phant-term.class.aux T CN (w-params.nil _ _ ML) PF RevParams Out :-
+  Out = {phant-fun-struct-and-class {std.rev RevParams} T CN `c` T c\
+          {mk-phant-term.class-mixins {std.rev RevParams} T CN c (ML T) PF}}.
 
-pred mk-phant-mixins.body i:list-w-params mixinname, i:list classname, i:term, i:list term, o:phant-term.
-mk-phant-mixins.body (w-params.cons N Ty ML) CNL EtaF Params PhBody :-
+pred mk-phant-term.body i:list-w-params mixinname, i:list classname, i:term, i:list term, o:phant-term.
+mk-phant-term.body (w-params.cons N Ty ML) CNL EtaF Params PhBody :-
   @pi-decl N Ty p\
-    mk-phant-mixins.body (ML p) CNL {subst-fun [p] EtaF} [p|Params] (PhBody1 p),
+    mk-phant-term.body (ML p) CNL {subst-fun [p] EtaF} [p|Params] (PhBody1 p),
     phant-fun (real-arg `p`) Ty PhBody1 PhBody.
 
-mk-phant-mixins.body (w-params.nil N TTy _ML) CNL EtaF _Params PhBody :-
+mk-phant-term.body (w-params.nil N TTy _ML) CNL EtaF _Params PhBody :-
   @pi-decl N TTy t\
-    std.fold CNL (phant-term [] {subst-fun [t] EtaF}) (mk-phant-mixins.class t)
+    std.fold CNL (phant-term [] {subst-fun [t] EtaF}) (mk-phant-term.class t)
       (PhBody1 t),
     phant-fun (real-arg N) TTy PhBody1 PhBody.
 
-pred mk-phant-mixins i:term, o:phant-term.
-mk-phant-mixins F PhBody:- std.do! [
-  std.assert-ok! (coq.typecheck F FTy) "mk-phant-mixins: F illtyped",
+pred mk-phant-term i:term, o:phant-term.
+mk-phant-term F PhBody:- std.do! [
+  std.assert-ok! (coq.typecheck F FTy) "mk-phant-term: F illtyped",
   ty-deps FTy MLwP,
   mk-eta (-1) FTy F EtaF,
 %  toposort-mixins ML MLSorted,
   MLwP = MLwPSorted, % Assumes we give them already sorted in dep order.
   std.rev {list-w-params_list MLwPSorted} MLSortedRev,
   find-max-classes MLSortedRev CNL,
-  mk-phant-mixins.body MLwPSorted CNL EtaF [] PhBody,
+  mk-phant-term.body MLwPSorted CNL EtaF [] PhBody,
 ].
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -1390,9 +1403,6 @@ mk-class-field ClassName _ (field _ "class" (app [global ClassName|Args]) _\end-
   the-type Params T,
   std.append Params [T] Args.
 
-pred mk-parameter i:implicit_kind, i:name, i:term, i:(term -> indt-decl), o:indt-decl.
-mk-parameter IK Name X F Decl :- !, Decl = parameter {coq.name->id Name} IK X F.
-
 % Builds the axioms record and the factories from this class to each mixin
 % TODO params
 pred declare-class+structure i:list-w-params mixinname, o:factoryname, o:term, o:term, o:term, o:list prop.
@@ -1760,7 +1770,7 @@ declare-factory-alias Ty1 GRFSwP Module TheType TheParams :- std.do! [
 
   coq.env.end-section,
 
-  mk-phant-mixins (global GRK) PhGRK0,
+  mk-phant-term (global GRK) PhGRK0,
   if (mixin-first-class F _) (PhGRK = PhGRK0) (append-phant-unify PhGRK0 PhGRK),
   mk-phant-abbrev "Build" PhGRK BuildConst _,
 
@@ -1807,7 +1817,7 @@ declare-mixin-or-factory Sort1 Fields0 GRFSwP Module TheType D TheParams :- std.
   % TODO: should this be in the Exports module?
   if-verbose (coq.say "HB: declare notation axioms"),
 
-  mk-phant-mixins (global GRK) PhGRK0,
+  mk-phant-term (global GRK) PhGRK0,
 
   if-verbose (coq.say "HB: declare notation Axioms"),
 

--- a/hb.elpi
+++ b/hb.elpi
@@ -28,9 +28,12 @@
      begin defined
    - FooAlias
      see phant-abbrev, used to talk about the non canonical name of Foo
+   - when foo is the constructor of a data type with type A1 -> .. -> AN -> t
+     we define mk-foo as:
+       mk-foo A1 .. AN (foo A1 .. AN)
 */
 
-shorten coq.{ term->gref, subst-fun, safe-dest-app, mk-app, mk-eta }.
+shorten coq.{ term->gref, subst-fun, safe-dest-app, mk-app, mk-eta, subst-prod }.
 
 %%%%%%%%% Elpi Utils %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % This code could be moved in Elpi's standard library
@@ -70,6 +73,9 @@ list-eq-set L1 L2 :- list-diff L1 L2 [], list-diff L2 L1 [].
 pred mk-n-holes i:int, o:list A.
 mk-n-holes 0 [] :- !.
 mk-n-holes N [HOLE_|R] :- M is N - 1, mk-n-holes M R.
+
+pred under.do! i:((A -> Prop) -> A -> prop), i:list prop.
+under.do! Then LP :- Then (_\ std.do! LP) _.
 
 %%%%% HB Utils %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -127,7 +133,8 @@ name-of-asset-decl (asset-record X _ _ _) X.
 name-of-asset-decl (asset-alias X _) X.
 
 pred argument->asset i:argument, o:asset-decl.
-argument->asset (indt-decl (parameter ID _ Ty I)) (asset-parameter ID Ty A) :-
+argument->asset (indt-decl (parameter ID _ImplicitStatus Ty I)) (asset-parameter ID Ty A) :-
+  % Should we check that _ImplicitStatus is explicit?
   coq.string->name ID Name,
   @pi-decl Name Ty a\
     argument->asset (indt-decl (I a)) (A a).
@@ -167,6 +174,16 @@ copy-fields (field C N T R) (field C N T1 R1) :-
   copy T T1,
   pi x\ copy x x => copy-fields (R x) (R1 x).
 
+pred copy-triple i:(A -> A1 -> prop), i:(B -> B1 -> prop), i:(C -> C1 -> prop), i:triple A B C, o:triple A1 B1 C1.
+copy-triple F G H (triple X Y Z) (triple X1 Y1 Z1) :- F X X1, G Y Y1, H Z Z1.
+
+pred triple_1 i:triple A B C, o:A.
+triple_1 (triple A _ _) A.
+
+pred copy-list i:(A -> A1 -> prop), i:list A, o: list A1.
+copy-list _ [] [].
+copy-list F [X|XS] [Y|YS] :- F X Y, copy-list F XS YS.
+
 pred gref->modname i:mixinname, o:id.
 gref->modname GR ModName :-
   coq.gref->path GR Path,
@@ -174,6 +191,134 @@ gref->modname GR ModName :-
 
 pred term->modname i:structure, o:id.
 term->modname T ModName :- gref->modname {term->gref T} ModName.
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% function to predicate generic constructions %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+pred mk-nil o:any.
+mk-nil [].
+pred mk0 i:any, o:any.
+mk0 F R :- constant R F [].
+pred mk1 i:any, i:any, o:any.
+mk1 F X1 R :- constant R F [X1].
+pred mk2 i:any, i:any, i:any, o:any.
+mk2 F X1 X2 R :- constant R F [X1, X2].
+pred mk3 i:any, i:any, i:any, i:any, o:any.
+mk3 F X1 X2 X3 R :- constant R F [X1, X2, X3].
+pred mk4 i:any, i:any, i:any, i:any, i:any, o:any.
+mk4 F X1 X2 X3 X4 R :- constant R F [X1, X2, X3,X4].
+
+%%%%%%%%%%%%%%%%%%%%%%
+% w-params interface %
+%%%%%%%%%%%%%%%%%%%%%%
+
+pred apply-w-params i:w-params A, i:list term, i:term, o:A.
+apply-w-params (w-params.cons _ _ PL) [P|PS] T R :- !, apply-w-params (PL P) PS T R.
+apply-w-params (w-params.nil _ _ L) [] T R :- !, R = L T.
+apply-w-params _ _ _ _ :- coq.error "apply-w-params".
+
+pred w-params.nparams i:w-params A, o:int.
+w-params.nparams (w-params.cons _ _ F) N :- pi x\ w-params.nparams (F x) M, N is M + 1.
+w-params.nparams (w-params.nil _ _ _) 0.
+
+% generic argument to pass to w-params
+pred ignore i:name, i:term, i:(term -> A), o:A.
+ignore _ _ F X :- (pi x y\ F x = F y), X = F (sort prop).
+
+% combining body and type
+pred mk-fun-prod i:name, i:term, o:(term -> pair term term), o:pair term term.
+mk-fun-prod N Ty (x\ pr (Body x) (Type x)) (pr (fun N Ty Body) (prod N Ty Type)).
+
+% [w-params.then AwP Nil Cons Pred Out] states that Out has shape
+%   Cons `x_1` T_1 p_1 \ .. \ Nil `T` {{Type}} t \ Body
+%   where the-type [p_1 .. p_n] T => Pred Body
+pred the-type o:list term, o:term.
+pred w-params.then i:w-params A,
+   i:(name -> term -> (term -> B) -> C -> prop),
+   i:(name -> term -> (term -> C) -> C -> prop),
+   i:(A -> B -> prop),
+   o:C.
+w-params.then L Nil Cons P O :- w-params.then.params L Nil Cons [] P O.
+
+pred w-params.then.params i:w-params A,
+   i:(name -> term -> (term -> B) -> C -> prop),
+   i:(name -> term -> (term -> C) -> C -> prop),
+   i:list term, % accumulator
+   i:(A -> B -> prop), o:C.
+w-params.then.params (w-params.cons N PTy ML) Nil Cons RevParams Pred Out :-
+  @pi-decl N PTy p\
+    w-params.then.params (ML p) Nil Cons [p|RevParams] Pred (Body p),
+    Cons N PTy Body Out.
+w-params.then.params (w-params.nil NT TTy ML) Nil _ RevParams Pred Out :-
+  std.rev RevParams Params,
+  @pi-decl NT TTy t\ the-type Params t => Pred (ML t) (Body t),
+    Nil NT TTy Body Out.
+
+pred w-params.map i:w-params A, i:(A -> B -> prop), o:w-params B.
+w-params.map AL F BL :- w-params.then AL (mk3 w-params.nil) (mk3 w-params.cons) F BL.
+
+% on the fly abstraction
+pred bind-nil i:name, i:term, i:term, i:A, o:w-params A.
+bind-nil N T X V (w-params.nil N T A) :- V = A X.
+
+pred bind-cons i:name, i:term, i:term, i:w-params A, o:w-params A.
+bind-cons N T X V (w-params.cons N T A) :- V = A X.
+
+% Specific to list-w-params
+pred list-w-params_list i:list-w-params A, o:list A.
+list-w-params_list AwP R :- w-params.then AwP ignore ignore (x\ std.map x triple_1) R.
+
+pred list-w-params.append i:list-w-params A, i:list-w-params A, o:list-w-params A.
+list-w-params.append (w-params.nil N T ML1) (w-params.nil N T ML2) (w-params.nil N T ML) :-
+  pi x\ std.append (ML1 x) (ML2 x) (ML x).
+list-w-params.append (w-params.cons N Ty ML1) (w-params.cons N Ty ML2) (w-params.cons N Ty ML) :-
+  pi x\ list-w-params.append (ML1 x) (ML2 x) (ML x).
+
+pred list-w-params.flatten-map
+  i:list-w-params A,
+  i:(A -> list-w-params B -> prop),
+  o:list-w-params B.
+list-w-params.flatten-map (w-params.cons N T L) F (w-params.cons N T L1) :-
+  @pi-decl N T p\
+    list-w-params.flatten-map (L p) F (L1 p).
+list-w-params.flatten-map (w-params.nil N TTy L) F (w-params.nil N TTy L1) :-
+  @pi-decl N TTy t\
+    list-w-params.flatten-map.aux (L t) F (L1 t).
+
+pred list-w-params.flatten-map.aux
+  i:list (w-args A), i:(A -> list-w-params B -> prop), o:list (w-args B).
+list-w-params.flatten-map.aux [] _ [].
+list-w-params.flatten-map.aux [triple M Ps T|L] F Res1 :-
+  F M MwP,
+  apply-w-params MwP Ps T ML,
+  list-w-params.flatten-map.aux L F Res,
+  std.append ML Res Res1.
+
+% [build-list-w-params TheParams TheType Factorties ListWParams]
+% Params is a list of pairs (section variable, its type).
+% ListWParams has as many w-params.cons as TheParams and the terms
+% in Factories are abstracted wrt the first component of TheParams.
+pred build-list-w-params i:list (pair term term), i:term, i:list (w-args A), o: list-w-params A.
+build-list-w-params [pr P Pty|PS] TheType Factories (w-params.cons `p` Pty1 R) :- std.do! [
+  copy Pty Pty1,
+  (pi p\ (copy P p :- !) => build-list-w-params PS TheType Factories (R p)),
+].
+build-list-w-params [] TheType Factories (w-params.nil `t` TT R) :- std.do! [
+  std.assert-ok! (coq.typecheck TheType TT) "BUG: TheType does not typecheck",
+  (pi t\ (copy TheType t :- !) =>
+         std.map Factories (copy-triple (=) (copy-list copy) copy) (R t)),
+].
+
+pred distribute-w-params i:list-w-params A, o:list (one-w-params A).
+distribute-w-params (w-params.cons N T F) L :-
+  pi x\ distribute-w-params (F x) (L1 x), std.map (L1 x) (bind-cons N T x) L.
+distribute-w-params (w-params.nil N T F) L :-
+  pi x\ std.map (F x) (bind-nil N T x) L.
+
+% Specific to one-w-params
+pred w-params_1 i:one-w-params A, o:A.
+w-params_1 X Y :- w-params.then X ignore ignore triple_1 Y.
 
 %%%%%%%%% HB database %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -183,6 +328,9 @@ acc S CL :- coq.elpi.accumulate S "hb.db" CL.
 
 pred from_mixin i:prop, o:mixinname.
 from_mixin (from _ X _) X.
+
+pred from_builder i:prop, o:term.
+from_builder (from _ _ X) X.
 
 pred mixin-src_mixin i:prop, o:mixinname.
 mixin-src_mixin (mixin-src _ M _) M.
@@ -201,34 +349,79 @@ factory-alias->gref PhGR GR :- phant-abbrev GR PhGR _, !.
 factory-alias->gref GR GR :- phant-abbrev GR _ _, !.
 
 pred sub-class? i:class, i:class.
-sub-class? (class _ _ ML1) (class _ _ ML2) :-
+sub-class? (class _ _ ML1P) (class _ _ ML2P) :-
+  list-w-params_list ML1P ML1,
+  list-w-params_list ML2P ML2,
   std.forall ML2 (m2\ std.exists ML1 (m1\ m1 = m2)).
 
+% TODO: maybe the right API is to have this
+% pred factory-provides i:factoryname, i:list-w-params mixiname.
+% one can use w-params.then now!
 % [factory-provides F ML] computes the mixins ML generated by F
-pred factory-provides i:factoryname, o:list mixinname.
-factory-provides FactoryAlias ML :- std.do! [
+pred factory-provides i:factoryname, o:list-w-params mixinname.
+factory-provides FactoryAlias MLwP :- std.do! [
   factory-alias->gref FactoryAlias Factory,
-  std.findall (from Factory T_ F_) All,
-  std.map All from_mixin ML,
+  factory-requires Factory RMLwP,
+  w-params.map RMLwP (factory-provides.base Factory) MLwP
 ].
 
-% [factories-provide FL ML] computes the mixins ML generated by all F in FL
-pred factories-provide i:list factoryname, o:list mixinname.
-factories-provide GRFS ML :- std.do! [
-  std.map GRFS factory-provides MLUnsortedL,
-  std.flatten MLUnsortedL MLUnsorted,
-  toposort-mixins MLUnsorted ML,
+pred factory-provides.base i:factoryname, i:list (w-args mixinname), o:list (w-args mixinname).
+factory-provides.base Factory _RMLwP MLwP :- std.do! [
+  std.findall (from Factory T_ F_) All,
+  std.map All from_mixin ML,
+  std.map All from_builder BL,
+  the-type Params T,
+  std.map2 BL ML (factory-provides.one Params T) MLwP,
 ].
+
+pred factory-provides.one i:list term, i:term, i:term, i:mixinname, o:w-args mixinname.
+factory-provides.one Params T B M (triple M PL T) :- std.do! [
+  std.assert-ok! (coq.typecheck B Ty) "Builder illtyped",
+  subst-prod [T] {subst-prod Params Ty} TyParams,
+  std.assert! (extract-conclusion-params TyParams PL) "The conclusion of a builder is a mixin whose parameters depend on other mixins",
+].
+
+pred extract-conclusion-params i:term, o:list term.
+extract-conclusion-params (prod _ S T) R :- !,
+  @pi-decl _ S x\ extract-conclusion-params (T x) R.
+extract-conclusion-params (app [global GR|Args]) R :- !,
+  factory-alias->gref GR Factory,
+  factory-nparams Factory NP,
+  std.take NP Args R.
+extract-conclusion-params T R :- whd1 T T1, !, extract-conclusion-params T1 R.
+
+
+% [factories-provide FL ML] computes the mixins ML generated by all F in FL
+%
+%  cons tp p\ nil t\ [pr f1 [p,t]]
+%    f1 p t = m1 t, m2 p t
+%  cons tp p\ nil t\ [pr m1 [t], pr m2 [p,t]]
+pred factories-provide i:list-w-params factoryname, o:list-w-params mixinname.
+factories-provide FLwP MLwP :-
+  list-w-params.flatten-map FLwP factory-provides UnsortedMLwP,
+  w-params.map UnsortedMLwP toposort-mixins MLwP.
 
 % Mixins can be topologically sorted according to their dependencies
 pred toposort-mixins.mk-mixin-edge i:prop, o:list (pair mixinname mixinname).
 toposort-mixins.mk-mixin-edge (factory-requires M Deps) L :-
-  std.map Deps (d\r\ r = pr d M) L.
-pred toposort-mixins i:list mixinname, o:list mixinname.
+  std.map {list-w-params_list Deps} (d\r\ r = pr d M) L.
+
+pred toposort-mixins i:list (w-args mixinname), o:list (w-args mixinname).
 toposort-mixins In Out :- std.do! [
   std.findall (factory-requires M_ Deps_) AllMixins,
   std.flatten {std.map AllMixins toposort-mixins.mk-mixin-edge} ES,
-  toposort ES In Out,
+  toposort-proj triple_1 ES In Out,
+].
+
+pred toposort-proj i:(A -> B -> prop), i:list (pair B B), i:list A, o:list A.
+toposort-proj Proj ES In Out :- !, toposort-proj.acc Proj ES [] In Out.
+pred topo-find i:B, o:A.
+pred toposort-proj.acc i:(A -> B -> prop), i:list (pair B B), i:list B, i:list A, o:list A.
+toposort-proj.acc _ ES Acc [] Out :- !,
+  std.map {toposort ES Acc} topo-find Out.
+toposort-proj.acc Proj ES Acc [A|In] Out :- std.do![
+  Proj A B,
+  topo-find B A => toposort-proj.acc Proj ES [B|Acc] In Out
 ].
 
 % Classes can be topologically sorted according to the subclass relation
@@ -313,13 +506,18 @@ get-structure-class-projection (global (indt S)) (global (const P)) :-
   coq.CS.canonical-projections S L,
   if (L = [_, some P]) true (coq.error "No canonical class projection for" S).
 
-pred get-structure-constructor i:structure, o:term.
-get-structure-constructor (global (indt S)) (global (indc K)) :-
-  if (coq.env.indt S _ 0 0 _ [K] _) true (coq.error "Not a packed structure" S).
+pred get-structure-constructor i:structure, i:list term, o:term.
+get-structure-constructor (global (indt S)) Params T :-
+  if (coq.env.indt S _ _ NParams _ [K] _) true (coq.error "Not a packed structure" S),
+  std.assert! ({std.length Params} = NParams) "get-structure-constructor: wrong number of params",
+  mk-app (global (indc K)) Params T.
 
-pred get-class-constructor i:classname, o:term.
-get-class-constructor (indt S) (global (indc K)) :-
-  if (coq.env.indt S _ 1 1 _ [K] _) true (coq.error "Not a class" S).
+pred get-class-constructor i:classname, i:list term, o:term.
+get-class-constructor (indt S) Params T :-
+  if (coq.env.indt S _ _ NParams _ [K] _) true (coq.error "Not a class" S),
+ if ({std.length [_|Params]} = NParams) true
+    (coq.error "get-class-constructor: wrong number of params:" S),
+  mk-app (global (indc K)) Params T.
 
 %% finding for locally defined structures
 pred get-cs-structure i:cs-instance, o:term.
@@ -362,10 +560,10 @@ under-canonical-mixins-of.do! T P :-
 
 %%%%% mterm %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-% A mterm is always of the form [mterm ML F], which is a pair of
-% a list of mixins ML that should be substituted in F and a term F
+% (mterm A) is always of the form [mterm ML F], which is a pair of
+% a list of mixins ML that should be substituted in F and a termF
 kind mterm type.
-type mterm list mixinname -> term -> mterm.
+type mterm list term -> term -> list mixinname -> term -> mterm.
 
 % Notations /à la/ *pack* are always of the shape
 % [Notation N x_0 .. x_n := C x_0 .. _ _ id .. x_i .. _ id _ _ id]
@@ -388,11 +586,25 @@ type unify-arg phant-arg.
 kind phant-term type.
 type phant-term list phant-arg -> term -> phant-term.
 
-% [builder->term T Src Tgt MF] provides a term which is
+pred phant-fun i:phant-arg, i:term, i:(term -> phant-term), o:phant-term.
+phant-fun Arg Ty PhF (phant-term [Arg|ArgL] (fun N Ty F)) :-
+  if (Arg = real-arg N) true (N = `_`),
+  pi x\ PhF x = phant-term ArgL (F x).
+
+pred print-ctx.
+print-ctx :- declare_constraint print-ctx [].
+constraint print-ctx mixin-src {
+  rule \ (G ?- print-ctx) | (coq.say "The context is:" G).
+}
+
+% [builder->term Params T Src Tgt MF] provides a term which is
 % a function to transform Src into Tgt under the right mixin-src.
-pred builder->term i:term, i:factoryname, i:mixinname, o:term.
-builder->term T Src Tgt FT :- !, std.do! [
-  from Src Tgt F, factory-requires Src ML, mterm->term T (mterm ML F) FT].
+pred builder->term i:list term, i:term, i:factoryname, i:mixinname, o:term.
+builder->term Ps T Src Tgt FT :- !, std.do! [
+  from Src Tgt F,
+  factory-requires Src MLwP,
+  list-w-params_list MLwP ML,
+  mterm->term (mterm Ps T ML F) FT].
 
 % [instantiate-mixin T F M_i TFX] where mixin-for T M_i X_i states that
 % if    F  ~  fun xs (m_0 : M_0 T) .. (m_n : M_n T ..) ys
@@ -410,29 +622,30 @@ instantiate-mixin T M (fun N Ty F) (fun N Ty FX) :- !,
   pi m\ instantiate-mixin T M (F m) (FX m).
 instantiate-mixin _ _ F F.
 
-% [mterm->term T MF TFX] assumes that MF is a mterm
+% [mterm->term MF TFX] assumes that MF is a mterm
 % (mterm ML F) and perform the substitution as above
 % for every mixin-for entry out of the list ML = [M_0, .., M_n].
-pred mterm->term i:term, i:mterm, o:term.
-mterm->term T (mterm ML F) SFX :- std.do! [
+pred mterm->term i:mterm, o:term.
+mterm->term (mterm Ps T ML F) SFX :- std.do! [
   std.assert-ok! (coq.typecheck F Ty) "mterm->term: F illtyped",
   mk-eta (-1) Ty F EtaF,
-  subst-fun [T] EtaF FT,
+  subst-fun {std.append Ps [T]} EtaF FT,
   std.fold ML FT (instantiate-mixin T) SFX
 ].
 
-% [mgref->term T GR X] computes the dependencies of GR in mixins,
+% [mgref->term Params T GR X] computes the dependencies of GR in mixins,
 % (through factory-requires if it exist, otherwise gr-deps)
 % and instanciates all of them through mixin-src, and fails if it cannot.
-pred mgref->term i:term, i:gref, o:term.
-mgref->term T GR X :- factory-requires GR ML, !, std.do! [
-  mterm->term T (mterm ML (global GR)) X
+pred mgref->term i:list term, i:term, i:gref, o:term.
+mgref->term Ps T GR X :- factory-requires GR MLwP, !, std.do! [
+  list-w-params_list MLwP ML,
+  mterm->term (mterm Ps T ML (global GR)) X
 ].
-mgref->term T GR X :- !, std.do! [
-  std.assert! (gr-deps GR ML) "BUG: gr-deps should never fail",
-  mterm->term T (mterm ML (global GR)) X
+mgref->term Ps T GR X :- !, std.do! [
+  std.assert! (gr-deps GR MLwP) "BUG: gr-deps should never fail",
+  list-w-params_list MLwP ML,
+  mterm->term (mterm Ps T ML (global GR)) X
 ].
-
 
 % [mixin-srcs T X MSL] states that MSL is a list of [mixin-src T m X]
 % where m ranges all the mixins that the factory Src can provide,
@@ -446,37 +659,42 @@ mixin-srcs T X MSL :- std.do! [
                 "\nwhich is not a record")
      true,
   term->gref XTy Src,
-  factory-alias->gref Src Factory,
-  factory-provides Factory ML,
+  factory-provides Src MLwP,
+  list-w-params_list MLwP ML,
   % TODO: skip mixins for which there is already a source.
   std.map ML (m\r\ r = mixin-src T m X) MSL
 ].
 
 pred under-mixin-src-from-factory.then i:term, i:term, i:(term -> prop), o:term.
-under-mixin-src-from-factory.then TheType TheFactory P X :-
+under-mixin-src-from-factory.then TheType TheFactory P X :- std.do![
   mixin-srcs TheType TheFactory ML,
-  ML => P X.
+  ML => P X
+].
 
 pred under-mixin-src-from-factory.do! i:term, i:term, i:list prop.
-under-mixin-src-from-factory.do! TheType TheFactory P :-
-  mixin-srcs TheType TheFactory ML,
-  ML => std.do! P.
+under-mixin-src-from-factory.do! TheType TheFactory LP :-
+  under.do! (under-mixin-src-from-factory.then TheType TheFactory) LP.
 
-pred under-mixin-src-from-factories.do! i:term, i:list term, i:list prop.
-under-mixin-src-from-factories.do! TheType Factories P :-
+pred under-mixin-src-from-factories.then i:term, i:list term, i:(term -> prop), o:term.
+under-mixin-src-from-factories.then TheType Factories P X :-
   std.map Factories (mixin-srcs TheType) MLL,
   std.flatten MLL ML,
-  ML => std.do! P.
+  ML => P X.
+
+pred under-mixin-src-from-factories.do! i:term, i:list term, i:list prop.
+under-mixin-src-from-factories.do! TheType Factories LP :-
+  under.do! (under-mixin-src-from-factories.then TheType Factories) LP.
 
 % [mixin-for T M X] states that X has type [M T ...]
 % it is reconstructed from two databases [mixin-src] and [from]
 pred mixin-for o:term, o:mixinname, o:term.
 mixin-for T M MI :- mixin-src T M Tm, !, std.do! [
   std.assert-ok! (coq.typecheck Tm Ty) "mixin-for: Tm illtyped",
-  term->gref Ty Src,
-  factory-alias->gref Src Factory,
+
+  factory? Ty (triple Factory Params _),
+
   if (M = Factory) (MI = Tm) (
-      builder->term T Factory M F,
+      builder->term Params T Factory M F,
       subst-fun [Tm] F MI
   )
 ].
@@ -485,27 +703,58 @@ mixin-for T M MI :- mixin-src T M Tm, !, std.do! [
 
 % [ty-deps Ty ML] states that ML is the list of
 % mixins which the type Ty rely on, i.e.
-% Ty = forall (m_0 : M_0 T) ... (m_n : M_n T ..), _ and ML = [M_0, .., M_n]
-pred ty-deps i:term, o:list mixinname.
-ty-deps (prod N S R) ML' :- !,
+% Ty = forall p_1 ... p_n (T : Type) (m_0 : M_0 T) ... (m_n : M_n T ..), (zero : T), ..... axioms_ T
+% ML = [M_0, .., M_n]
+% pred ty-deps i:term, o:list-w-params mixinname.
+% ty-deps (prod N S R) ML' :- !,
+%   @pi-decl N S x\
+%     ty-deps (R x) ML,
+%     safe-dest-app S HD _,
+%     if (HD = global GR, factory-alias->gref GR F, from  _ F _, !)
+%       (ML' = [F|ML]) (ML' = ML).
+% ty-deps Ty ML :- whd1 Ty Ty1, !, ty-deps Ty1 ML.
+% ty-deps _Ty [].
+
+pred factory? i:term, o:w-args factoryname.
+factory? S (triple F Params T) :-
+  safe-dest-app S (global GR) Args, factory-alias->gref GR F, factory-nparams F NP, !,
+  std.split-at NP Args Params [T|_].
+
+pred prod-src-is-factory i:term.
+prod-src-is-factory (prod _ S _) :- factory? S _.
+prod-src-is-factory Ty :- whd1 Ty Ty1, !, prod-src-is-factory Ty1.
+
+pred ty-deps i:term, o:list-w-params mixinname.
+ty-deps Ty ML :- ty-deps.aux Ty ML, !.
+ty-deps (prod N T _) (w-params.nil N T _\[]) :- T = {{Type}}, !.
+ty-deps T _ :- % TODO: forall p1 ... pn (T : indexed Type) with indexed being the id function
+  coq.error "ty-deps: BUG: could not get the parameters and the dependencies of"
+    {coq.term->string T}.
+ty-deps.aux (prod N S R) ML :- !,
   @pi-decl N S x\
-    ty-deps (R x) ML,
-    safe-dest-app S HD _,
-    if (HD = global GR, factory-alias->gref GR F, from  _ F _, !)
-      (ML' = [F|ML]) (ML' = ML).
-ty-deps Ty ML :- whd1 Ty Ty1, !, ty-deps Ty1 ML.
-ty-deps _Ty [].
+    if (prod-src-is-factory (R x))
+      (ML = w-params.nil  N S MLP, ty-deps.factories (R x) (MLP x))
+      (ML = w-params.cons N S ML1, ty-deps.aux (R x) (ML1 x)).
+ty-deps.aux Ty ML :- whd1 Ty Ty1, !, ty-deps.aux Ty1 ML.
+
+pred ty-deps.factories i:term, o:list (w-args factoryname).
+ty-deps.factories (prod N S R) FS :-
+  @pi-decl N S x\
+    if (factory? S FwP) (FS = [FwP|FS1]) (FS = FS1),
+    ty-deps.factories (R x) FS1.
+ty-deps.factories Ty FS :- whd1 Ty Ty1, !, ty-deps.factories Ty1 FS.
+ty-deps.factories _ [].
 
 % [term-deps T ML] states that ML is the list of
 % mixins which the term T rely on, i.e. T has type
 % forall (m_0 : M_0 T) ... (m_n : M_n T ..), _ and ML = [M_0, .., M_n]
-pred term-deps i:term, o:list mixinname.
+pred term-deps i:term, o:list-w-params mixinname.
 term-deps T ML :-
   std.assert-ok! (coq.typecheck T Ty) "term-deps: T illtyped",
   ty-deps Ty ML.
 
 % shorthand for gref.
-pred gr-deps i:gref, o:list mixinname.
+pred gr-deps i:gref, o:list-w-params mixinname.
 gr-deps GR ML :- term-deps (global GR) ML.
 
 % [find-max-classes Mixins Classes] states that Classes is a list of classes
@@ -513,27 +762,42 @@ gr-deps GR ML :- term-deps (global GR) ML.
 % Although it is not strictly necessary, but desirable for debugging,
 % we use a heuristic that tries to minimize the number
 % of classes by assuming Mixins are reversed topologically sorted.
+% Note: works with flat mixins, no params
 pred find-max-classes i:list mixinname, o:list classname.
 find-max-classes [] [].
 find-max-classes [M|Mixins] [C|Classes] :-
   mixin-first-class M C,
   std.do! [
-    class-def (class C _ ML),
+    class-def (class C _ MLwP),
+    list-w-params_list MLwP ML,
     std.filter Mixins (x\ not (std.mem! ML x)) Mixins',
     find-max-classes Mixins' Classes
   ].
 find-max-classes [M|_] _ :- coq.error "cannot find a class containing mixin" M.
 
-% [mk-mixin-fun.then T ML Pred F] states that F has type
-% fun (m_0 : M_0 T) .. (m_n : M_n T m_i0 .. m_ik) => Body m_0 .. m_n
-% where ML = [M_0, .., M_n]
-% and Body is such that [..,mixin-src T M_i m_i,..] => Pred Body
-pred mk-mixin-fun.then i:term, i:list gref, i:(term -> prop), o:term.
-mk-mixin-fun.then _T [] Pred Body :- !, Pred Body.
-mk-mixin-fun.then T [M|ML] Pred (fun `m` MTy FLG) :- std.do! [
-  mgref->term T M MTy,
-  @pi-decl `m` MTy m\ mixin-src T M m => mk-mixin-fun.then T ML Pred (FLG m)
-].
+pred under-mixins.then i:list (w-args mixinname),
+    i:(name -> term -> (term -> A) -> A -> prop),
+    i:(A -> prop), o:A.
+under-mixins.then [] _ Pred Body :- !, Pred Body.
+under-mixins.then [triple M Args T|ML] Mixin Pred Out :- std.do! [
+  mgref->term Args T M MTy,
+  @pi-decl `m` MTy m\ mixin-src T M m => under-mixins.then ML Mixin Pred (Body m),
+  Mixin `m` MTy Body Out
+  ].
+
+pred mk-fun i:name, i:term, i:(term -> term), o:term.
+mk-fun N Ty Body (fun N Ty Body).
+
+% [mk-mixin-fun.then MLwP Pred F] states that F has shape
+%   fun p_1 .. p_k T,
+%      (m_0 : M_0 ..p.. T) .. (m_n : M_n ..p.. T m_i0 .. m_ik) =>
+%      Body m_0 .. m_n
+% where  MLwP contains M_0, .., M_n (under p_1 .. p_k)
+%   and  Body is such that [..,mixin-src T M_i m_i,..] => Pred Body
+%   and  ..p.. is a list of terms built using p_1 .. p_k and T
+pred mk-mixin-fun.then i:list-w-params mixinname, i:(term -> prop), o:term.
+mk-mixin-fun.then L P Out :- !,
+  w-params.then L mk-fun mk-fun (ml\ out\ under-mixins.then ml mk-fun P out) Out.
 
 % A *pack* notation can be easiliy produced from a phant-term using
 % [mk-phant-abbrev N PT C], which states that C is a new constant
@@ -590,57 +854,113 @@ mk-phant-struct T SI PF (phant-term [implicit-arg, unify-arg|AL] UF) :-
     (lib:hb.some (lib:hb.pair "is not canonically a"%string lp:SI)))
       => lp:(F s)}}.
 
-% [mk-phant-struct T CN PF PCF] states that PSF is a phant-term
-% which postulate a structure [s : SI] such that [T = sort s]
-% and a class [c : CN T] such that [s = CK T c] and then outputs [PF c]
-pred mk-phant-class i:term, i:classname, i:(term -> phant-term), o:phant-term.
-mk-phant-class T CN PF PSF :-
-    class-def (class CN SI _CML), get-structure-constructor SI SK,
-    PSF = {mk-phant-struct T SI s\
-            {mk-phant-implicit `c` (app [global CN, T]) c\
-              {mk-phant-unify s (app [SK, T, c]) (PF c)} } }.
-
-% [mk-phant-mixins F PF] states that if F = fun T m_0 .. m_n => _
+% [mk-phant-mixins F PF] states that if F = fun p1 .. p_k T m_0 .. m_n => _
 % then PF = phant-term
-%   [real-arg T, implicit-arg, unify-arg, implicit-arg, unify-arg,
+%   [real-arg p_1, ... real-arg p_k,
+%    real-arg T,
+%        implicit-arg, unify-arg, implicit-arg, unify-arg,
 %                implicit-arg, .., implicit-arg, unify-arg, ...,
 %                implicit-arg, unify-arg, implicit-arg, unify-arg,
 %                implicit-arg, .., implicit-arg, unify-arg]
-%   {{fun T => [find s_0 | T ~ s_0] [find c_0 | s_0 ~ SK T c_0]
-%              [find m_0_0, .., m_0_n0 | c_0 ~ CK m_0_0 .. m_0_n0] ...
-%              [find s_k | T ~ s_k] [find c_k | s_k ~ SK T c_k]
-%              [find m_k_0, .., m_k_nk | c_k ~ CK m_k_0 .. m_k_nk]
-%                F T m_i0_j0 .. m_il_jl}}
-pred mk-phant-mixins.class-mixins i:term, i:classname, i:term,
-  i:list mixinname, i:phant-term, o:phant-term.
-mk-phant-mixins.class-mixins T CN C [] PF UPF :- !, std.do![
-    get-class-constructor CN K, class-def (class CN _ CML),
-    mterm->term T (mterm CML K) KCML,
+%   {{fun p_1 ... p_k T =>
+%              fun q_1 .. q_l =>
+%                [find s_0 | T ~ s_0]
+%                [find c_0 | s_0 ~ SK q_1 .. q_l T c_0]
+%                [find m_0_0, .., m_0_n0 | c_0 ~ CK m_0_0 .. m_0_n0]
+%              ...
+%              fun q'_1 .. q'_l' =>
+%                [find s_k | T ~ s_k]
+%                [find c_k | s_k ~ SK q'_1 .. q'_l' T c_k]
+%                [find m_k_0, .., m_k_nk | c_k ~ CK m_k_0 .. m_k_nk]
+
+% Cyril: FIX so that
+% [mk-phant-mixins F PF] states that
+% if F = fun p1 .. p_k T m_0 .. m_n => _
+% then PF = phant-term
+%   [real-arg p_1, ... real-arg p_k, real-arg T, implicit-arg, .., implicit-arg,
+%       implicit-arg, .., implicit-arg,
+%         implicit-arg, unify-arg,
+%         implicit-arg, unify-arg,
+%         implicit-arg, .., implicit-arg, unify-arg,
+%         unify-arg, ..., unify-arg,
+%       ...,
+%       implicit-arg, .., implicit-arg,
+%         implicit-arg, unify-arg,
+%         implicit-arg, unify-arg,
+%         implicit-arg, .., implicit-arg, unify-arg,
+%         unify-arg, ..., unify-arg]
+%   {{fun p_1 ... p_k T m_0 .. m_n =>
+%       fun q_1 .. q_l =>
+%         [find s_0 | T ~ s_0]
+%         [find c_0 | s_0 ~ SK q_1 .. q_l T c_0]
+%         [find m'_{i_0_0}, .., m'_{i_0_n0} | c_0 ~ CK m'_{i_0_0} .. m'_{i_0_n0}]
+%         fun of hb.unify m_{i_0_0} m'_{i_0_0} & ... & hb.unify m_{i_0_n0} m'_{i_0_n0} =>
+%       ...
+%       fun q'_1 .. q'_l' =>
+%         [find s_k | T ~ s_k]
+%         [find c_k | s_k ~ SK q'_1 .. q'_l' T c_k]
+%         [find m'_{i_k_0}, .., m'_{i_k_nk} | c_0 ~ CK m'_{i_k_0} .. m'_{i_k_nk}]
+%         fun of hb.unify m_{i_0_0} m'_{i_0_0} & ... & hb.unify m_{i_k_nk} m'_{i_k_nk} =>
+%       F p_1 ... p_k T m_i0_j0 .. m_il_jl}}
+pred mk-phant-mixins.class-mixins i:list term, i:term, i:classname, i:term,
+  i:list (w-args mixinname), i:phant-term, o:phant-term.
+mk-phant-mixins.class-mixins Params T CN C [] PF UPF :- !, std.do![
+    get-class-constructor CN Params K, class-def (class CN _ CMLwP),
+    list-w-params_list CMLwP CML,
+    mterm->term (mterm Params T CML K) KCML,
     mk-phant-unify C KCML PF UPF].
-mk-phant-mixins.class-mixins T CN C [M|ML] (phant-term AL FMML) LamPFmmL :- !,
-    mgref->term T M MTy,
+mk-phant-mixins.class-mixins Params T CN C [triple M Args _|ML] (phant-term AL FMML) LamPFmmL :- !,
+    mgref->term Args T M MTy,
     (@pi-decl `m` MTy m\ mixin-src T M m => sigma FmML\
       instantiate-mixin T M FMML FmML,
-      mk-phant-mixins.class-mixins T CN C ML (phant-term AL FmML) (PFmmL m)),
+      mk-phant-mixins.class-mixins Params T CN C ML (phant-term AL FmML) (PFmmL m)),
     mk-phant-implicit `m` MTy PFmmL LamPFmmL.
 
 pred mk-phant-mixins.class i:term, i:classname, i:phant-term, o:phant-term.
 mk-phant-mixins.class T CN PF SCF :- !,
-    class-def (class CN _SI CML),
-    SCF = {mk-phant-class T CN c\ {mk-phant-mixins.class-mixins T CN c CML PF} }.
+  class-def (class CN SI CML),
+  get-structure-constructor SI [/*fixme params*/] SK,
+  mk-phant-mixins.class.aux T CN CML SI SK PF [] SCF.
+
+pred mk-phant-mixins.class.aux
+  i:term,
+  i:classname, i:list-w-params mixinname,
+  i:structure, i:term,
+  i:phant-term, i:list term, o:phant-term.
+mk-phant-mixins.class.aux T CN (w-params.cons N Ty ML) SI SK PF RevParams Out :-
+  Out = {mk-phant-implicit N Ty p\
+          {mk-phant-mixins.class.aux T CN (ML p) SI SK PF [p|RevParams]}}.
+mk-phant-mixins.class.aux T CN (w-params.nil _ _ ML) SI SK PF RevParams Out :-
+  MLT = ML T,
+  std.rev [T|RevParams] ClassArgs,
+  ClassTy = app [global CN|ClassArgs],
+  Out = {mk-phant-struct T SI s\
+          {mk-phant-implicit `c` ClassTy c\
+            {mk-phant-unify s (app [SK | {std.append ClassArgs [c]} ])
+              {mk-phant-mixins.class-mixins {std.rev RevParams} T CN c MLT PF}}}}.
+
+pred mk-phant-mixins.body i:list-w-params mixinname, i:list classname, i:term, i:list term, o:phant-term.
+mk-phant-mixins.body (w-params.cons N Ty ML) CNL EtaF Params PhBody :-
+  @pi-decl N Ty p\
+    mk-phant-mixins.body (ML p) CNL {subst-fun [p] EtaF} [p|Params] (PhBody1 p),
+    phant-fun (real-arg `p`) Ty PhBody1 PhBody.
+
+mk-phant-mixins.body (w-params.nil N TTy _ML) CNL EtaF _Params PhBody :-
+  @pi-decl N TTy t\
+    std.fold CNL (phant-term [] {subst-fun [t] EtaF}) (mk-phant-mixins.class t)
+      (PhBody1 t),
+    phant-fun (real-arg N) TTy PhBody1 PhBody.
 
 pred mk-phant-mixins i:term, o:phant-term.
-mk-phant-mixins F (phant-term [real-arg T|AL] (fun T _ CFML)) :- std.do! [
+mk-phant-mixins F PhBody:- std.do! [
   std.assert-ok! (coq.typecheck F FTy) "mk-phant-mixins: F illtyped",
-  ty-deps FTy ML,
+  ty-deps FTy MLwP,
   mk-eta (-1) FTy F EtaF,
 %  toposort-mixins ML MLSorted,
-  ML = MLSorted, % Assumes we give them already sorted in dep order.
-  std.rev MLSorted MLSortedRev,
+  MLwP = MLwPSorted, % Assumes we give them already sorted in dep order.
+  std.rev {list-w-params_list MLwPSorted} MLSortedRev,
   find-max-classes MLSortedRev CNL,
-  (@pi-decl T {{Type}} t\ sigma FML PML\
-    std.fold CNL (phant-term [] {subst-fun [t] EtaF}) (mk-phant-mixins.class t)
-      (phant-term AL (CFML t)))
+  mk-phant-mixins.body MLwPSorted CNL EtaF [] PhBody,
 ].
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -651,14 +971,20 @@ mk-phant-mixins F (phant-term [real-arg T|AL] (fun T _ CFML)) :- std.do! [
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+pred params->holes i:list-w-params A, o:list term.
+params->holes (w-params.nil _ _ _) [].
+params->holes (w-params.cons _ _ F) [_|PS] :- pi x\ params->holes (F x) PS.
+
 % Given a type T, a list of class definition in topological order (from least dep to most)
 % it consumes the list all the classes for which all the dependencies
 % (mixins) were postulated so far (skips the rest) and declares a local
 % constant inhabiting the corresponding structure and declares it canonical.
 pred declare-instances i:term, i:list class.
-declare-instances T [class Class Struct ML|Rest] :-
-  get-class-constructor Class KC,
-  mterm->term T (mterm ML KC) KCApp, % we can build it
+declare-instances T [class Class Struct MLwP|Rest] :-
+  params->holes MLwP Params,
+  get-class-constructor Class Params KC,
+  list-w-params_list MLwP ML,
+  mterm->term (mterm [/*Params already applied to KC*/] T ML KC) KCApp, % we can build it
   not (local-cs? T Struct), % not already built
   !,
   term->gref T TGR,
@@ -667,7 +993,7 @@ declare-instances T [class Class Struct ML|Rest] :-
 
   if-verbose (coq.say "HB: declare canonical instance" Name),
 
-  get-structure-constructor Struct KS,
+  get-structure-constructor Struct Params KS,
   S = app[KS, T, KCApp],
   std.assert-ok! (coq.typecheck S STy) "declare-instances: S illtyped",
 
@@ -692,7 +1018,7 @@ declare-factory-abbrev Name (factory-by-phantabbrev Abbr) :-
 % creates a clause in CL stating that GR requires ML (factory-requires ..), and
 % creates an abbreviation for GR names Str and creates a phant-abbrev clause in CL.
 % SN is the short name for the factory (either an alias of the class record)
-pred main-factory-requires i:string, i:gref, i:list factoryname, o:list prop, o:factory-name.
+pred main-factory-requires i:string, i:gref, i:list-w-params factoryname, o:list prop, o:factory-name.
 main-factory-requires Str GR GRFS [FactoryRequires|Aliases] SN :- !, std.do! [
   factories-provide GRFS ML,
   FactoryRequires = factory-requires GR ML,
@@ -704,77 +1030,83 @@ main-factory-requires Str GR GRFS [FactoryRequires|Aliases] SN :- !, std.do! [
       SN = factory-by-phantabbrev Abbrv),
 ].
 
-pred main-mixin-requires i:string, i:gref, i:list factoryname, o:list prop, o:factory-name.
+% [main-mixin-requires S GR FL CL SN]
+% calls main-factory-requires and appends the identity builders for the mixin
+pred main-mixin-requires i:string, i:gref, i:list-w-params factoryname, o:list prop, o:factory-name.
 main-mixin-requires Str GR GRFS [From|PO] SN :- !, std.do! [
   main-factory-requires Str GR GRFS PO SN,
   % register factory
   PO => std.do! [
-    coq.env.typeof GR (prod T TTy _),
-    @pi-decl T TTy t\ mk-mixin-fun.then t {factory-requires GR} (body\ sigma MTy\
-        mgref->term t GR MTy,
-        body = fun `x` MTy x\x) (IDBody t)],
-  From = from GR GR (fun T TTy IDBody),
+    mk-mixin-fun.then {factory-requires GR}
+      (body\ sigma MTy Params T\
+        the-type Params T,
+        mgref->term Params T GR MTy,
+        body = fun `x` MTy x\x)
+      IDBody
+  ],
+  std.assert-ok! (coq.typecheck IDBody _) "identity builder illtyped",
+  From = from GR GR IDBody,
 ].
 
 % Given a type T, a fresh number N, and a mixin M it postulates
 % a variable "mN" inhabiting M applied to T and
 % all its dependencies, previously postulated and associated
 % to the corresponding mixin using mixin-for
-pred postulate-mixin i:term, i:mixinname, i:list prop, o:list prop.
-postulate-mixin T M MSL [mixin-src T M (global (const C))|MSL] :- MSL => std.do! [
+pred postulate-mixin i:w-args mixinname, i:list prop, o:list prop.
+postulate-mixin (triple M Ps T) MSL [mixin-src T M (global (const C))|MSL] :- MSL => std.do! [
   Name is "mixin_" ^ {gref->modname M},
 
   if-verbose (coq.say "HB: postulate" Name "on" {coq.term->string T}),
 
-  mgref->term T M Ty,
+  mgref->term Ps T M Ty,
   std.assert-ok! (coq.typecheck Ty _) "postulate-mixin: Ty illtyped",
   coq.env.add-const Name _ Ty tt tt C % no body, local -> a variable
 ].
 
 % Postulates a context with all the mixins provided by the factories
-pred main-declare-context i:term, i:list factoryname, o:list prop.
-main-declare-context T GRFS MSL :-  std.do! [
-  factories-provide GRFS ML,
-  std.fold ML [] (postulate-mixin T) MSL,
-  MSL => declare-instances T {findall-classes},
+pred main-declare-context i:term, i:list term, i:list-w-params factoryname, o:list prop.
+main-declare-context TheType TheParams GRFSwP MSL :-  std.do! [
+  factories-provide GRFSwP MLwP,
+  apply-w-params MLwP TheParams TheType MLwAllArgs,
+  std.fold MLwAllArgs [] postulate-mixin MSL,
+  MSL => declare-instances TheType {findall-classes},
   std.forall MSL (ms\ acc current (clause _ _ ms)),
 ].
 
 % [factory-comp TheType SrcFactory MB MiddleFactory TgtMixin B1] synthesizes
 %   B1 = MB o B
-% where B is the builder from MiddleFactory to TgtMixin and
-% MB is a builder from SrcFactory to MiddleFactory
-pred factory-comp i:term, i:factoryname, i:mterm, i:factoryname, i:mixinname, o:term.
-factory-comp TheType SrcFactory MB MiddleFactory TgtMixin MBoB :-
-  mgref->term TheType SrcFactory Src,
-  MBoB = {{
+% where MB is the builder from MiddleFactory to TgtMixin and
+% B is a builder from SrcFactory to MiddleFactory
+pred factory-comp i:list mixinname, i:factoryname, i:term, i:factoryname, i:mixinname, o:term.
+factory-comp ML SrcFactory B MiddleFactory TgtMixin Comp :-
+  the-type TheParams TheType,
+  mgref->term TheParams TheType SrcFactory Src,
+  MB = mterm TheParams TheType ML B,
+  Comp = {{
     fun src : lp:Src => lp:{{
       {under-mixin-src-from-factory.then TheType {{src}}
-        (factory-comp-body TheType {{src}} MB MiddleFactory TgtMixin)} }}
+        (factory-comp-body {{src}} MB MiddleFactory TgtMixin)} }}
   }}.
 
-pred factory-comp-body i:term, i:term, i:mterm, i:factoryname, i:mixinname, o:term.
-factory-comp-body TheType TheFactory MB MiddleFactory TgtMixin MBoB :- std.do! [
-  mterm->term TheType MB MB1,
+pred factory-comp-body i:term, i:mterm, i:factoryname, i:mixinname, o:term.
+factory-comp-body TheFactory (mterm TheParams TheType _ _ as MB) MiddleFactory TgtMixin Comp :- std.do! [
+  mterm->term MB MB1,
   subst-fun-opt TheFactory MB1 MB2,
-  builder->term TheType MiddleFactory TgtMixin B,
-  subst-fun [MB2] B MBoB
+  builder->term TheParams TheType MiddleFactory TgtMixin B2,
+  subst-fun [MB2] B2 Comp
 ].
 
-% [declare-builder ML Src F Mid Tgt FromI FromO]
-% declares a builder by composing F and G.
+% [declare-builder Src SrcRequires F Fty Mid Tgt FromI FromO]
+% declares a builder by composing F and Mid.
 pred declare-builder
-  i:gref, i:list mixinname, i:term, i:term, i:gref, i:gref, i:list prop, o:list prop.
-declare-builder SrcFactory SrcFactoryRequires B BTy MiddleFactory TgtMixin FromI [NewFrom|FromI] :- !, FromI => std.do! [
-  std.assert! (BTy = prod _ TTy _) "declare-builder: B is not a function",
+  i:gref, i:list-w-params mixinname, i:term, i:term, i:gref, i:gref, i:list prop, o:list prop.
+declare-builder SrcFactory SrcFactoryRequires F FTy MiddleFactory TgtMixin FromI [NewFrom|FromI] :- !, FromI => std.do! [
+  std.assert! (FTy = prod _ _ _) "declare-builder: B is not a function",
 
-  MB = mterm SrcFactoryRequires B, % a B that we can fulfill with the context
+  list-w-params_list SrcFactoryRequires ML, % args of F we can fulfill with the context
 
-  GoF = {{
-    fun t : lp:TTy => lp:{{ % a fun for the type
-      {mk-mixin-fun.then {{t}} SrcFactoryRequires
-        (factory-comp {{t}} SrcFactory MB MiddleFactory TgtMixin)} }}
-  }},
+  GoF = {mk-mixin-fun.then SrcFactoryRequires
+          (factory-comp ML SrcFactory F MiddleFactory TgtMixin)},
 
   std.assert-ok! (coq.typecheck GoF _GoFTy) "declare-builder: GoF illtyped",
   Name is {gref->modname SrcFactory} ^ "_to_" ^ {gref->modname TgtMixin} ^ {term_to_string {new_int}},
@@ -790,13 +1122,17 @@ main-declare-builder (builder _ SrcFactory B) FromClauses MoreFromClauses :- !, 
   FromClauses => std.do! [
     std.assert-ok! (coq.typecheck B BTy) "main-declare-builder: B illtyped",
     factory-alias->gref {target-gref BTy} MiddleFactory,
-    factory-requires SrcFactory SrcFactoryRequires,
-    factory-provides MiddleFactory AllTgtMixins,
+    factory-requires SrcFactory SrcFactoryRequireswP,
+    list-w-params_list SrcFactoryRequireswP SrcFactoryRequires,
+
+    factory-provides MiddleFactory AllTgtMixinswP,
+    list-w-params_list AllTgtMixinswP AllTgtMixins,
+
     std.filter AllTgtMixins (t\ not (std.mem! SrcFactoryRequires t)) TgtMixins,
   ],
   if-verbose (coq.say "HB: declare builders from" {nice-gref->string SrcFactory}
                       "to" {std.map TgtMixins nice-gref->string}),
-  std.fold TgtMixins FromClauses (declare-builder SrcFactory SrcFactoryRequires B BTy MiddleFactory) MoreFromClauses,
+  std.fold TgtMixins FromClauses (declare-builder SrcFactory SrcFactoryRequireswP B BTy MiddleFactory) MoreFromClauses,
 ].
 
 % [export Module] exports a Module now adds it to the collection of
@@ -807,76 +1143,156 @@ export Module :- !,
   coq.env.export-module Module,
   acc current (clause _ _ (to-export Module)).
 
-pred mk-mixin-fun i:term, i:list mixinname, i:term, o:term.
-mk-mixin-fun T ML X MLX :- mk-mixin-fun.then T ML (body\ body = X) MLX.
+pred mk-mixin-fun i:list-w-params mixinname, i:term, o:term.
+mk-mixin-fun ML X MLX :- mk-mixin-fun.then ML (body\ body = X) MLX.
 
-pred clean-op-ty i:list prop, i:term, i:term, i:term, o:term.
-clean-op-ty [] _ _ T1 T2 :- copy T1 T2.
-clean-op-ty [exported-op _ Po C|Ops] SortPTheStructure TheStructure T1 T2 :-
-  gr-deps (const Po) ML,
-  mk-mixin-fun SortPTheStructure ML (app [global (const C), TheStructure]) EtaC,
-  (pi L T R H S\
-    copy (app [global (const Po), T|L]) R :- hd-beta EtaC L H S, unwind H S R) =>
-    clean-op-ty Ops SortPTheStructure TheStructure T1 T2.
+% const Po : forall p1 .. pm T m1 .. mn, Extra  (Eg Extra = forall x y, x + y = y + z)
+% const C : forall p1 .. pm s, Extra
+% Po P1 .. PM T M1 .. MN PoArgs -> C P1 .. PM S PoArgs
+pred clean-op-ty i:list prop, i:term, i:term, o:term.
+clean-op-ty [] _ T1 T2 :- copy T1 T2.
+clean-op-ty [exported-op _ Po C|Ops] S T1 T2 :-
+  gr-deps (const Po) MLwP,
+  w-params.nparams MLwP NParams,
+  std.length {list-w-params_list MLwP} NMixins,
+
+  (pi L L1 Params Rest PoArgs\
+    copy (app [global (const Po)| L]) (app [global (const C) | L1]) :-
+      std.split-at NParams L Params [_|Rest],
+      std.drop NMixins Rest PoArgs,
+      std.append Params [S|PoArgs] L1) =>
+
+  clean-op-ty Ops S T1 T2.
+
+pred operation-body-and-ty i:list prop, i:constant, i:term, i:term, i:term,
+  i:w-args A, o:pair term term.
+operation-body-and-ty EXI Poperation Struct Psort Pclass (triple _ Params _) (pr Bo Ty) :- std.do! [
+  mk-app Struct Params StructType,
+  mk-app Psort Params PsortP,
+  mk-app Pclass Params PclassP,
+  Bo = fun `s` StructType Body,
+  Ty = prod `s` StructType BodyTy,
+  (@pi-decl `s` StructType s\ sigma Carrier Class\ std.do! [
+      mk-app PsortP [s] Carrier,
+      mk-app PclassP [s] Class,
+      under-mixin-src-from-factory.do! Carrier Class [
+        % just in case..
+        the-type Params Carrier => mgref->term Params Carrier (const Poperation) (Body s),
+        std.assert-ok! (coq.typecheck (Body s) (DirtyTy s)) "export-1-operation: Body illtyped",
+        clean-op-ty EXI s (DirtyTy s) (BodyTy s),
+      ],
+  ]),
+].
 
 % given an operation (a mixin projection) we generate a constant projection the
 % same operation out of the package structure (out of the class field of the
 % structure). We also provide all the other mixin dependencies (other misins)
 % of the package structure.
-pred export-1-operation i:mixinname, i:term, i:term, i:term, i:option constant, i:list prop, o:list prop.
-export-1-operation _ _ _ _ none EX EX :- !. % not a projection, no operation
-export-1-operation M Struct Psort Pclass (some Poperation) EXI EXO :- !, std.do! [
+pred export-1-operation i:mixinname, i:term, i:term, i:term, i:one-w-params mixinname, i:option constant, i:list prop, o:list prop.
+export-1-operation _ _ _ _ _ none EX EX :- !. % not a projection, no operation
+export-1-operation M Struct Psort Pclass MwP (some Poperation) EXI EXO :- !, std.do! [
   coq.gref->id (const Poperation) Name,
-  (@pi-decl `s` Struct s\ sigma Carrier Class MSL DirtyTy Copies\ std.do! [
-      Carrier = app[Psort, s],
-      Class = app[Pclass, s],
-      under-mixin-src-from-factory.do! Carrier Class [
-        mgref->term Carrier (const Poperation) (Body s)
-      ],
-      std.assert-ok! (coq.typecheck (Body s) DirtyTy) "export-1-operation: Body illtyped",
-      clean-op-ty EXI Carrier s DirtyTy (BodyTy s)]
-  ),
-  T = fun `x` Struct Body,
-  Ty = prod `x` Struct BodyTy,
+
+  w-params.then MwP ignore mk-fun-prod (operation-body-and-ty EXI Poperation Struct Psort Pclass) (pr Body BodyTy),
 
   if-verbose (coq.say "HB: export operation" Name),
+  coq.env.add-const Name Body BodyTy ff ff C,
 
-  coq.env.add-const Name T Ty ff ff C,
-  coq.arguments.set-implicit (const C) [[maximal]] tt,
+  w-params.nparams MwP NP,
+  NImplicits is NP + 1,
+  std.map {std.iota NImplicits} (_\r\ r = maximal) Implicits,
+  coq.arguments.set-implicit (const C) [Implicits] tt,
+
   EXO = [exported-op M Poperation C|EXI]
 ].
 
 % Given a list of mixins, it exports all operations in there
-pred export-operations.aux i:term, i:term, i:term, i:list mixinname, i:list prop, o:list prop.
-export-operations.aux _ _ _ [] EX EX.
-export-operations.aux Struct ProjSort ProjClass [indt M|ML] EX1 EX3 :- !, std.do! [
+pred export-operations.aux i:term, i:term, i:term, i:one-w-params mixinname, i:list prop, o:list prop.
+export-operations.aux Struct ProjSort ProjClass MwP EX1 EX2 :- !, std.do! [
+  w-params_1 MwP (indt M),
   coq.CS.canonical-projections M Poperations,
-  std.fold Poperations EX1 (export-1-operation (indt M) Struct ProjSort ProjClass) EX2,
-  export-operations.aux Struct ProjSort ProjClass ML EX2 EX3
+  std.fold Poperations EX1 (export-1-operation (indt M) Struct ProjSort ProjClass MwP) EX2,
 ].
-export-operations.aux Struct ProjSort ProjClass [GR|ML] EXI EXO:-
-  coq.say GR "is not a record: skipping operations factory this mixin",
-  export-operations.aux Struct ProjSort ProjClass ML EXI EXO.
 
-pred export-operations i:term, i:term, i:term, i:list mixinname, i:list prop, o:list prop, o:list mixinname.
-export-operations Structure ProjSort ProjClass ML EXI EXO MLToExport :-
-  std.filter ML (m\ not(mixin-first-class m _)) MLToExport,
-  export-operations.aux Structure ProjSort ProjClass MLToExport EXI EXO.
+pred mixin-not-already-declared i:one-w-params mixinname.
+mixin-not-already-declared MwP :-
+  w-params_1 MwP M, not(mixin-first-class M _), M = indt _.
+
+pred export-operations i:term, i:term, i:term, i:list-w-params mixinname, i:list prop, o:list prop, o:list mixinname.
+export-operations Structure ProjSort ProjClass MLwP EX1 EX2 MLToExport :- std.do! [
+  distribute-w-params MLwP LMwP,
+  std.filter LMwP mixin-not-already-declared LMwPToExport,
+  std.fold LMwPToExport EX1 (export-operations.aux Structure ProjSort ProjClass) EX2,
+  std.map LMwPToExport w-params_1 MLToExport,
+].
 
 pred reexport-1-operation i:prop.
 reexport-1-operation (exported-op _M _P C) :-
   add-abbrev {coq.gref->id (const C)} 0 (global (const C)) tt ff _.
 pred reexport-operations i:list mixinname.
-reexport-operations ML :- std.do![
+reexport-operations ML :- std.do! [
   std.flatten {std.map ML (m\ std.findall (exported-op m Poperation_ C_))} PL,
   std.forall PL reexport-1-operation
+].
+
+pred mk-coe-class-body
+  i:factoryname, % From class
+  i:factoryname, % To class
+  i:list-w-params mixinname, % To mixins
+  i:list (w-args mixinname),
+  o:term.
+mk-coe-class-body FC TC TMLwP _ CoeBody :- std.do! [
+  the-type Params T,
+  mk-app (global FC) Params ClassKP,
+  mk-app ClassKP [T] Class,
+
+  list-w-params_list TMLwP TML,
+  std.map TML (from FC) Builders,
+  std.map Builders (x\r\mk-app x Params r) BuildersP,
+
+  factory-nparams TC NHoles,
+  mk-n-holes NHoles Holes,
+  get-class-constructor TC Holes KC,
+
+  (pi c\ sigma Mixes\
+    std.map BuildersP (builder\r\ r = app[builder, T, c]) Mixes,
+    ClassCoercion c = app[KC, T | Mixes]),
+
+  CoeBody = {{ fun (c : lp:Class) => lp:(ClassCoercion c) }}
+].
+
+pred mk-coe-structure-body
+  i:structure, % From structure
+  i:structure, % To structure
+  i:factoryname, % To factory (for nparams)
+  i:term, % class coercion
+  i:term, % sort projection
+  i:term, % class projection
+  i:list (w-args mixinname),
+  o:term.
+mk-coe-structure-body StructureF StructureT TC Coercion SortProjection ClassProjection _ SCoeBody :- std.do! [
+  the-type Params _T,
+  mk-app StructureF Params StructureP,
+
+  factory-nparams TC NHoles,
+  mk-n-holes NHoles Holes,
+  get-structure-constructor StructureT Holes PackPH,
+
+  mk-app SortProjection Params SortP,
+  mk-app ClassProjection Params ClassP,
+
+  mk-app Coercion Params CoercionP,
+
+  SCoeBody = {{ fun s : lp:StructureP =>
+     let T : Type := lp:SortP s in
+     lp:PackPH T (lp:CoercionP T (lp:ClassP s)) }},
 ].
 
 % [declare-coercion P1 P2 C1 C2] declares a structure and a class coercion
 % from C1 to C2 given P1 P2 the two projections from the structure of C1
 pred declare-coercion i:term, i:term, i:class, i:class.
 declare-coercion SortProjection ClassProjection
-    (class FC StructureF _ as FCDef) (class TC StructureT TML as TCDef) :- std.do! [
+    (class FC StructureF FMLwP as FCDef) (class TC StructureT TMLwP as TCDef) :- std.do! [
 
   acc current (clause _ _ (sub-class FCDef TCDef)),
 
@@ -885,13 +1301,11 @@ declare-coercion SortProjection ClassProjection
   CName is ModNameF ^ "_class_to_" ^ ModNameT ^ "_class",
   SName is ModNameF ^ "_to_" ^ ModNameT,
 
-  std.map TML (from FC) FC2TML,
-  get-class-constructor TC KC,
-  Class = global FC,
-  (pi T c\ sigma Mixes\
-    std.map FC2TML (p\r\ r = app[p, T, c]) Mixes,
-    ClassCoercion T c = app[KC, T | Mixes]),
-  CoeBody = {{ fun (T : Type) (c : lp:Class T) => lp:(ClassCoercion T c) }},
+  if-verbose (coq.say "HB: declare coercion" SName),
+
+  w-params.then FMLwP mk-fun mk-fun
+    (mk-coe-class-body FC TC TMLwP) CoeBody,
+
   std.assert-ok! (coq.typecheck CoeBody Ty) "declare-coercion: CoeBody illtyped",
 
   if-verbose (coq.say "HB: declare coercion hint" CName),
@@ -899,11 +1313,11 @@ declare-coercion SortProjection ClassProjection
   coq.env.add-const CName CoeBody Ty ff ff C,
   coq.coercion.declare (coercion (const C) 1 FC (grefclass TC)) tt,
 
-  get-structure-constructor StructureT Pack,
   Coercion = global (const C),
-  SCoeBody = {{ fun s : lp:StructureF =>
-     let T : Type := lp:SortProjection s in
-     lp:Pack T (lp:Coercion T (lp:ClassProjection s)) }},
+  w-params.then FMLwP ignore mk-fun
+    (mk-coe-structure-body StructureF StructureT TC Coercion SortProjection ClassProjection)
+    SCoeBody,
+
   std.assert-ok! (coq.typecheck SCoeBody STy) "declare-coercion: SCoeBody illtyped",
 
   if-verbose (coq.say "HB: declare unification hint" SName),
@@ -921,7 +1335,7 @@ declare-join (class C3 S3 _) (pr (class C1 S1 _) (class C2 S2 _)) (join C1 C2 C3
   get-structure-coercion S3 S1 S3_to_S1,
   get-structure-sort-projection S1 S1_sort,
   get-structure-class-projection S2 S2_class,
-  get-structure-constructor S2 S2_Pack,
+  get-structure-constructor S2 [/*fixme params*/] S2_Pack,
 
   JoinBody = {{ fun s : lp:S3 =>
                    lp:S2_Pack (lp:S1_sort (lp:S3_to_S1 s))
@@ -955,43 +1369,55 @@ declare-unification-hints SortProj ClassProj CurrentClass NewJoins :- std.do! [
 
 % For each mixin we declare a field and apply the mixin to its dependencies
 % (that are previously declared fields recorded via field-for-mixin)
-pred synthesize-fields i:term, i:list mixinname,o:record-decl.
+pred synthesize-fields i:term, i:list (w-args mixinname), o:record-decl.
 synthesize-fields _T []     end-record.
-synthesize-fields T  [M|ML] (field _ Name MTy Fields) :- std.do! [
+synthesize-fields T  [triple M Args _|ML] (field _ Name MTy Fields) :- std.do! [
   Name is {gref->modname M} ^ "_mixin",
-  mgref->term T M MTy,
+  mgref->term Args T M MTy,
   @pi-decl `m` MTy m\ mixin-src T M m => synthesize-fields T ML (Fields m)
 ].
 
+pred synthesize-fields.body i:list (w-args mixinname), o:indt-decl.
+synthesize-fields.body ML (record "axioms" {{ Type }} "Class" FS) :-
+  the-type _ T,
+  synthesize-fields T ML FS.
+
+pred mk-record+sort-field i:name, i:term, i:(term -> record-decl), o:indt-decl.
+mk-record+sort-field _ T F (record "type" {{ Type }} "Pack" (field _ "sort" T F)).
+
+pred mk-class-field i:classname, i:list (w-args mixinname), o:record-decl.
+mk-class-field ClassName _ (field _ "class" (app [global ClassName|Args]) _\end-record) :-
+  the-type Params T,
+  std.append Params [T] Args.
+
+pred mk-parameter i:implicit_kind, i:name, i:term, i:(term -> indt-decl), o:indt-decl.
+mk-parameter IK Name X F Decl :- !, Decl = parameter {coq.name->id Name} IK X F.
+
 % Builds the axioms record and the factories from this class to each mixin
-pred declare-class i:list mixinname, o:factoryname, o:list prop.
-declare-class ML (indt ClassName) Factories :- std.do! [
+% TODO params
+pred declare-class+structure i:list-w-params mixinname, o:factoryname, o:term, o:term, o:term, o:list prop.
+declare-class+structure MLwP (indt ClassInd) Structure SortProjection ClassProjection AllFactories :- std.do! [
 
   if-verbose (coq.say "HB: declare axioms record"),
 
-  (@pi-decl `T` {{Type}} t\ synthesize-fields t ML (RDecl t)),
-  ClassDeclaration =
-    (parameter "T" explicit {{ Type }} t\
-      record "axioms" {{ Type }} "Class" (RDecl t)),
-  std.assert-ok! (coq.typecheck-indt-decl ClassDeclaration) "declare-class: illtyped",
-  coq.env.add-indt ClassDeclaration ClassName,
-  coq.CS.canonical-projections ClassName Projs,
-  std.map2 ML Projs (m\ p\ r\ sigma P\
-    p = some P,
-    r = from (indt ClassName) m (global (const P))) Factories
-].
+  w-params.then MLwP (mk-parameter explicit) (mk-parameter explicit)
+    synthesize-fields.body ClassDeclaration,
 
-% Builds the package record
-pred declare-structure i:factoryname, o:term, o:term, o:term.
-declare-structure ClassName Structure SortProjection ClassProjection :- std.do! [
+  std.assert-ok! (coq.typecheck-indt-decl ClassDeclaration) "declare-class: illtyped",
+  coq.env.add-indt ClassDeclaration ClassInd,
+  coq.CS.canonical-projections ClassInd Projs,
+  % TODO: put this code in a named clause
+  w-params.nparams MLwP NParams,
+  std.map2 {list-w-params_list MLwP} Projs (m\ p\ r\ sigma P\
+    p = some P,
+    r = from (indt ClassInd) m (global (const P))) Factories,
+  AllFactories = [factory-nparams (indt ClassInd) NParams | Factories],
 
   if-verbose (coq.say "HB: declare type record"),
 
-  StructureDeclaration =
-    record "type" {{ Type }} "Pack" (
-      field _ "sort" {{ Type }} s\
-      field _ "class" (app [global ClassName, s]) _\ % on Coq 8.11 we should replace _ with [canonical ff]
-    end-record),
+  w-params.then MLwP mk-record+sort-field (mk-parameter explicit)
+    (mk-class-field (indt ClassInd)) StructureDeclaration,
+
   std.assert-ok! (coq.typecheck-indt-decl StructureDeclaration) "declare-structure: illtyped",
   coq.env.add-indt StructureDeclaration StructureName,
 
@@ -1011,18 +1437,24 @@ declare-sort-coercion (global StructureName) (global Proj) :-
 
 pred if-class-already-exists-error i:Name, i:list class, i:list mixinname.
 if-class-already-exists-error _ [] _.
-if-class-already-exists-error N [class _ S ML1|CS] ML2 :-
+if-class-already-exists-error N [class _ S ML1wP|CS] ML2 :-
+  list-w-params_list ML1wP ML1,
   if (list-eq-set ML1 ML2)
      (coq.error "Structure" {coq.term->string S} "contains the same mixins of" N)
      (if-class-already-exists-error N CS ML2).
 
-pred main-declare-structure i:string, i:list gref, i:bool.
-main-declare-structure Module GRFS ClosureCheck :- std.do! [
-  factories-provide GRFS  PML,
+% HB.structure Definition S P1 P2 := { T of F1 P1 T & F2 P1 (P2*P2) T }
+%  cons p1\ cons p2\ nil t\ [triple f1 [p1] t,triple f2 [p1, {{p1 * p2}}] t]
+pred main-declare-structure i:string, i:list-w-params gref, i:bool.
+main-declare-structure Module GRFSwP ClosureCheck :- std.do! [
+  factories-provide GRFSwP  PMLwP,
 
-  std.map GRFS factory-requires RML,
-  std.flatten [PML|RML] UnsortedML,
-  toposort-mixins UnsortedML ML,
+  list-w-params.flatten-map GRFSwP factory-requires RMLwP, % TODO: extract code from factories-provide
+  list-w-params.append PMLwP RMLwP UnsortedMLwP,
+  w-params.map UnsortedMLwP toposort-mixins MLwP,
+
+  list-w-params_list PMLwP PML,
+  list-w-params_list MLwP ML,
 
   if (ClosureCheck = tt, not({std.length PML} = {std.length ML}))
      (coq.warn "pulling in dependencies:" {std.map {list-diff ML PML} nice-gref->string}
@@ -1037,12 +1469,15 @@ main-declare-structure Module GRFS ClosureCheck :- std.do! [
 
   coq.env.begin-module Module none,
 
-  declare-class ML  ClassName Factories,
-  ClassRequires = factory-requires (ClassName) [],
-  ClassAlias = (factory-alias->gref ClassName ClassName),
+  declare-class+structure MLwP
+    ClassName Structure SortProjection ClassProjection Factories,
 
-  declare-structure ClassName  Structure SortProjection ClassProjection,
-  CurrentClass = (class ClassName Structure ML),
+  w-params.map MLwP (_\ mk-nil) NilwP,
+  ClassRequires = factory-requires (ClassName) NilwP,
+  ClassAlias = (factory-alias->gref ClassName ClassName),
+  CurrentClass = (class ClassName Structure MLwP),
+
+  %declare-structure MLwP ClassName  Structure SortProjection ClassProjection,
 
   if-verbose (coq.say "HB: start module Exports"),
 
@@ -1050,7 +1485,7 @@ main-declare-structure Module GRFS ClosureCheck :- std.do! [
   declare-sort-coercion Structure SortProjection,
   if-verbose (coq.say "HB: exporting operations"),
   ClassAlias => ClassRequires => Factories =>
-    export-operations Structure SortProjection ClassProjection ML [] EX MLToExport,
+    export-operations Structure SortProjection ClassProjection MLwP [] EX MLToExport,
   if-verbose (coq.say "HB: exporting unification hints"),
   ClassAlias => ClassRequires => Factories =>
     declare-unification-hints SortProjection ClassProjection CurrentClass NewJoins,
@@ -1080,6 +1515,7 @@ main-declare-structure Module GRFS ClosureCheck :- std.do! [
   declare-factory-abbrev Module (factory-by-classname ClassName),
 ].
 
+/* HB.context?
 pred main-begin-declare i:string, i:string, i:list gref, i:declaration.
 main-begin-declare Module TName GRFS Decl :- std.do! [
 
@@ -1092,9 +1528,10 @@ main-begin-declare Module TName GRFS Decl :- std.do! [
 
   coq.fresh-type Ty,
   coq.env.add-const TName _ Ty tt tt T, % no body, local -> a variable
-  main-declare-context (global (const T)) GRFS _,
+  main-declare-context (global (const T)) [] GRFS _, % TODO params
   acc current (clause _ _ (current-decl Decl))
 ].
+*/
 
 pred main-end-declare-builders.
 main-end-declare-builders :- std.do! [
@@ -1124,15 +1561,14 @@ main-end-declare-builders :- std.do! [
   export Exports,
 ].
 
-pred main-declare-canonical-instances i:term, i:list term.
-main-declare-canonical-instances T FIL :- std.do! [
+pred main-declare-canonical-instances i:term, i:term.
+main-declare-canonical-instances T F :- std.do! [
   if (current-decl (builders-for-factory FGR))
-     (std.forall FIL (f\ sigma N\
-        new_int N, acc current (clause _ _ (builder-decl (builder N FGR f)))))
+     (new_int N, acc current (clause _ _ (builder-decl (builder N FGR F))))
      true,
-  under-mixin-src-from-factories.do! T FIL [
-  under-canonical-mixins-of.do! T [
-    declare-instances T {findall-classes}
+  under-mixin-src-from-factory.do! T F [
+    under-canonical-mixins-of.do! T [
+      declare-instances T {findall-classes}
   ]],
 ].
 
@@ -1152,26 +1588,28 @@ declare-old-constant (some C) :-
   std.forall {coq.locate-all Id} (declare-old-located Id).
 declare-old-constant _ :- true.
 
+pred context->factory i:context-decl, o:factoryname.
+context->factory (context-item IDT _ TTy none t\ context-item _ _ (TF t) none _\ context-end) GRF :- !,
+  coq.id->name IDT NameT,
+  @pi-decl NameT TTy t\
+    std.assert! (factory? (TF t) (triple GRF _Params t))
+      "the last argument must be a factory applied to the type variable".
+context->factory (context-item ID _ T none Factories) GRF :- !,
+  coq.id->name ID Name, @pi-decl Name T x\ context->factory (Factories x) GRF.
+context->factory (context-item ID _ _ (some _) _) _ :-
+  coq.error "context item cannot be given a body:" ID.
+
 pred main-begin-declare-builders i:context-decl.
-main-begin-declare-builders (context-item _ _ _ none _\ context-item IDF _ _ (some _) _\ context-end) :-
-    coq.error "factories cannot be given a body:" IDF.
-main-begin-declare-builders (context-item _ _ _ none _\ context-item ID1 _ _ none _\ context-item ID2 _ _ _ _) :-
-  coq.error "only one factory is supported, got at least two" ID1 "and" ID2.
-main-begin-declare-builders (context-item IDT _ T none t\ context-item IDF _ (F t) none _\ context-end) :- std.do! [
-  Name is "Builders_" ^ {term_to_string {new_int}}, % TODO
-  std.assert! (pi t\ F t = app[global GRA, t|_]) "a factory must be a name applied to the type variable",
-  factory-alias->gref GRA GRF,
+main-begin-declare-builders Ctx :- std.do! [
+  Name is "Builders_" ^ {term_to_string {new_int}}, % TODO?
+  context->factory Ctx GRF,
   coq.env.begin-module Name none,
   if (GRF = indt FRecord) (std.do! [
     coq.env.begin-module "Super" none,
     std.forall {coq.CS.canonical-projections FRecord} declare-old-constant,
     coq.env.end-module _]) (true),
   coq.env.begin-section Name,
-  std.assert! (T = sort (typ _)) "The first context item must be a type variable",
-  coq.fresh-type Ty,
-  coq.env.add-const IDT _ Ty tt tt C, % no body, local -> a variable
-  TheType = global (const C),
-  builders-postulate-factories IDF GRA GRF TheType [],
+  builders-postulate-factories Ctx,
 ].
 
 pred postulate-factory-abbrev i:term, i:id, i:factoryname, o:term.
@@ -1204,24 +1642,56 @@ define-factory-operation TheType TheFactory NHoles (some P) :-
   coq.gref->id (const P) Name,
   add-abbrev Name 0 T ff ff _.
 
-pred builders-postulate-factories i:string, i:gref, i:gref, i:term, i:list mixinname.
-builders-postulate-factories ID GRA GRF TheType GRML :- std.do! [
-  factory-requires GRF FML,
-  std.append GRML FML GRFML,
-  main-declare-context TheType GRFML _,
-  postulate-factory-abbrev TheType ID GRA TheFactory,
+pred builders-postulate-factories i:context-decl.
+builders-postulate-factories (context-item IDT _ TTy none t\ context-item IDF _ (TF t) none _\ context-end) :- !, std.do! [
+  % TODO we should allow T to be anything.
+  std.assert! (TTy = sort (typ _)) "The last context item before the factory must be a type variable",
+  coq.fresh-type Ty,
+  coq.env.add-const IDT _ Ty tt tt C, % no body, local -> a variable
+  TheType = global (const C),
+
+  std.assert! (factory? (TF TheType) (triple GRF Params TheType))
+    "the last argument must be a factory applied to the type variable",
+  factory-requires GRF GRFMLwP, % TODO: remove, pass to main-declare-context the list-w-params-eta-expansion of GRF
+  main-declare-context TheType Params GRFMLwP _,
+  postulate-factory-abbrev TheType IDF GRF TheFactory,
   define-factory-operations TheType TheFactory GRF,
   acc current (clause _ _ (current-decl (builders-for-factory GRF))),
 ].
 
+builders-postulate-factories (context-item ID _ T none Factories) :- std.do! [
+  coq.env.add-const ID _ T tt tt P, % no body, local -> a variable
+  TheParam = global (const P),
+  builders-postulate-factories (Factories TheParam),
+].
+
+builders-postulate-factories (context-item ID _ _ (some _) _) :-
+  coq.error "context item cannot be given a body:" ID.
+
+% In an asset like HB.mixing Recoord P1 .. PN A of F1 .. & FK ..
+% we call "named" P1 .. PN A, hence A is the last named asset param
+pred is-last-named-asset-param i:asset-decl.
+is-last-named-asset-param (asset-parameter _ {{ lib:hb.indexed _ }} _) :- !.
+is-last-named-asset-param (asset-parameter _ _ p\ asset-parameter _ (M p) _) :- pi p\ factory? (M p) _, !.
+is-last-named-asset-param (asset-parameter _ _ _\ asset-record _ _ _ _) :- !.
+is-last-named-asset-param (asset-parameter _ _ _\ asset-alias _ _) :- !.
+
+% main-declare-asset Asset AssetKind
 pred main-declare-asset i:asset-decl, i:asset.
-main-declare-asset (asset-parameter Name T Rest as R) D :- std.do! [
-  name-of-asset-decl R Module,
+main-declare-asset Asset AssetKind :- std.do! [
+  name-of-asset-decl Asset Module,
 
   if-verbose (coq.say "HB: start module and section" Module),
 
   coq.env.begin-module Module none,
   coq.env.begin-section Module,
+
+  process-asset-named-parameters Asset AssetKind Module [],
+].
+
+pred process-asset-named-parameters i:asset-decl, i:asset, i:id, i:list (pair term term).
+% We reached TheType
+process-asset-named-parameters (asset-parameter Name T Rest as R) D Module Params :- is-last-named-asset-param R, !, std.do! [
 
   if-verbose (coq.say "HB: postulate type" Name),
 
@@ -1229,32 +1699,51 @@ main-declare-asset (asset-parameter Name T Rest as R) D :- std.do! [
   coq.fresh-type Ty,
   coq.env.add-const Name _ Ty tt tt C, % no body, local -> a variable
   TheType = global (const C),
-  collect-asset-parameters (Rest TheType) [] Module TheType D
+  process-asset-unnamed-parameters (Rest TheType) [] Module TheType D {std.rev Params}
+].
+% This is a real parameter
+process-asset-named-parameters (asset-parameter Name T Rest) D Module Params :- std.do! [
+  std.assert-ok! (coq.typecheck-ty T _) "Illtyped parameter",
+  coq.env.add-const Name _ T tt tt C, % no body, local -> a variable
+  TheParam = global (const C),
+  process-asset-named-parameters (Rest TheParam) D Module [pr TheParam T|Params],
 ].
 
-pred collect-asset-parameters i:asset-decl, i:list factoryname, i:id, i:term, i:asset.
-collect-asset-parameters (asset-parameter _ T Rest) GRFS Module TheType D :- std.do! [
-  std.assert! (T = app[global F, TheType]) "Factory not applied to the type variable",
-  std.assert! (pi x y\ Rest x = Rest y) "Factories cannot be mentioned in the mixin",
+pred process-asset-unnamed-parameters
+  i:asset-decl, i:list (w-args factoryname), i:id, i:term, i:asset, i:list (pair term term).
+process-asset-unnamed-parameters (asset-parameter _ T Rest) FS Module TheType D Params :- std.do! [
+  std.assert! (factory? T (triple F Ps TheType)) "Not a factory applied to the type variable",
+  std.assert! (pi x y\ Rest y = Rest x) "Factories cannot be explicitly mentioned in the mixin",
   Dummy = sort prop,
-  collect-asset-parameters (Rest Dummy) [F|GRFS] Module TheType D
+  process-asset-unnamed-parameters (Rest Dummy) [triple F Ps TheType|FS] Module TheType D Params,
 ].
 
-collect-asset-parameters (asset-alias _ Ty) GRFS Module TheType D :-
-  std.assert! (D = asset-factory) "Mixins cannot be aliases",
-  % refresh implicit arguments, since many binders are now gone
-  (pi X Y\ copy X Y :- var X, !) => copy Ty Ty1,
-  declare-factory-alias Ty1 GRFS Module TheType.
+% (*) We did substitute bound variables by terms, we would end up outside the pattern fragment
+%  X x = (global(cont "foo"))        X := _\ (global ...)     1 solution
+%  X x = x                           X := a\a                 1 solution
+%  X x (global(cont "foo")) = (global(cont "foo"))   X := _\a\a   or   X := _\_\ (global ...)  2 solution, bad
 
-collect-asset-parameters (asset-record _ Sort _ Fields) GRFS Module TheType D :-
+process-asset-unnamed-parameters (asset-alias _ Ty) GRFS Module TheType D Params :- std.do! [
+  std.assert! (D = asset-factory) "Mixins cannot be aliases",
+  % refresh implicit arguments, since many binders are now gone (*)
+  (pi X Y\ copy X Y :- var X, !) => copy Ty Ty1,
+  build-list-w-params Params  TheType {std.rev GRFS} GRFSwParams,
+  declare-factory-alias Ty1 GRFSwParams Module TheType {std.map Params fst},
+].
+
+process-asset-unnamed-parameters (asset-record _ Sort _ Fields) GRFS Module TheType D Params :- std.do! [
   % refresh implicit arguments, since many binders are now gone
   (pi X Y\ copy X Y :- var X, !) => (copy-fields Fields Fields0, copy Sort Sort1),
-  declare-mixin-or-factory Sort1 Fields0 GRFS Module TheType D.
+  build-list-w-params Params  TheType {std.rev GRFS} GRFSwParams,
+  declare-mixin-or-factory Sort1 Fields0 GRFSwParams Module TheType D {std.map Params fst},
+].
 
-pred declare-factory-alias i:term, i:list factoryname, i:id, i:term.
-declare-factory-alias Ty1 GRFS Module TheType :- std.do! [
+pred declare-factory-alias i:term, i:list-w-params factoryname, i:id, i:term, i:list term.
+declare-factory-alias Ty1 GRFSwP Module TheType TheParams :- std.do! [
 
-  main-declare-context TheType {std.rev GRFS} Hyps,
+  % TODO maybe main-declare-context should just take GRFSwP and postulate
+  % the parameters and the type
+  main-declare-context TheType TheParams GRFSwP Hyps,
 
   std.assert-ok! (coq.typecheck-ty Ty1 _) "Illtyped alias factory",
   coq.env.add-const "axioms_" Ty1 _ ff ff C,
@@ -1263,7 +1752,7 @@ declare-factory-alias Ty1 GRFS Module TheType :- std.do! [
   std.assert! (factory-alias->gref PhF F) "BUG: Factory alias declaration missing",
   std.assert! (factory-constructor F FK) "BUG: Factory constructor missing",
 
-  Hyps => mgref->term TheType FK MFK,
+  Hyps => mgref->term TheParams TheType FK MFK,
   std.assert-ok! (coq.typecheck MFK MFKTy) "BUG: typecking of former factory constructor failed",
   (pi Args\ copy (app [global F|Args]) (global (const C))) => copy MFKTy MFKTyC,
   coq.env.add-const "Axioms_" MFK MFKTyC ff ff CK,
@@ -1275,8 +1764,9 @@ declare-factory-alias Ty1 GRFS Module TheType :- std.do! [
   if (mixin-first-class F _) (PhGRK = PhGRK0) (append-phant-unify PhGRK0 PhGRK),
   mk-phant-abbrev "Build" PhGRK BuildConst _,
 
-  std.map Hyps mixin-src_mixin ML,
-  main-factory-requires "axioms" (const C) ML Props SN,
+  % std.map Hyps mixin-src_mixin ML,
+  factories-provide GRFSwP MLwP,
+  main-factory-requires "axioms" (const C) MLwP Props SN,
 
   if-verbose (coq.say "HB: start module Exports"),
 
@@ -1284,8 +1774,10 @@ declare-factory-alias Ty1 GRFS Module TheType :- std.do! [
   (std.forall Props c\ acc current (clause _ _ c)),
   % std.map {gr-deps GRK} (_\ r\ r = maximal) Implicits,
   % coq.arguments.set-implicit GRK [[maximal|Implicits]] tt,
+  w-params.nparams MLwP NParams,
+  acc current (clause _ _ (factory-nparams (const C) NParams)),
   acc current (clause _ _ (factory-constructor (const C) GRK)),
-  acc current (clause _ _ (factory-builder-nparams BuildConst 0)),
+  acc current (clause _ _ (factory-builder-nparams BuildConst NParams)),
   coq.env.end-module Exports,
   coq.env.end-module _Module,
 
@@ -1296,11 +1788,11 @@ declare-factory-alias Ty1 GRFS Module TheType :- std.do! [
   declare-factory-abbrev Module SN,
 ].
 
-pred declare-mixin-or-factory i:term, i:record-decl, i:list factoryname, i:id, i:term, i:asset.
-declare-mixin-or-factory Sort1 Fields0 GRFS Module TheType D :- std.do! [
+pred declare-mixin-or-factory i:term, i:record-decl, i:list-w-params factoryname, i:id, i:term, i:asset, i:list term.
+declare-mixin-or-factory Sort1 Fields0 GRFSwP Module TheType D TheParams :- std.do! [
   if (D = asset-mixin) (Fields1 = Fields0)
      (Fields1 = (field _ "_" {{ lib:hb.unify lp:TheType lp:TheType lib:hb.none }} _\ Fields0)),
-  main-declare-context TheType {std.rev GRFS} Hyps,
+  main-declare-context TheType TheParams GRFSwP _Hyps,
 
   if-verbose (coq.say "HB: declare record axioms_"),
 
@@ -1322,19 +1814,22 @@ declare-mixin-or-factory Sort1 Fields0 GRFS Module TheType D :- std.do! [
   if (D = asset-mixin) (PhGRK = PhGRK0) (append-phant-unify PhGRK0 PhGRK),
   mk-phant-abbrev "Build" PhGRK BuildConst _,
 
-  std.map Hyps mixin-src_mixin ML,
+  % std.map Hyps mixin-src_mixin ML,
+  factories-provide GRFSwP MLwP,
   if (D = asset-mixin)
-     (main-mixin-requires "axioms" (indt R) ML Props SN)
-     (main-factory-requires "axioms" (indt R) ML Props SN),
+     (main-mixin-requires "axioms" (indt R) MLwP Props SN)
+     (main-factory-requires "axioms" (indt R) MLwP Props SN),
 
   if-verbose (coq.say "HB: start module Exports"),
 
   coq.env.begin-module "Exports" none,
   (std.forall Props c\ acc current (clause _ _ c)),
-  std.map {gr-deps GRK} (_\ r\ r = maximal) Implicits,
+  w-params.nparams MLwP NParams,
+  acc current (clause _ _ (factory-nparams (indt R) NParams)),
+  std.map {list-w-params_list {gr-deps GRK}} (_\ r\ r = maximal) Implicits,
   coq.arguments.set-implicit GRK [[maximal|Implicits]] tt,
   acc current (clause _ _ (factory-constructor (indt R) GRK)),
-  acc current (clause _ _ (factory-builder-nparams BuildConst 0)),
+  acc current (clause _ _ (factory-builder-nparams BuildConst NParams)),
   coq.env.end-module Exports,
   coq.env.end-module _Module,
 
@@ -1344,4 +1839,3 @@ declare-mixin-or-factory Sort1 Fields0 GRFS Module TheType D :- std.do! [
 
   declare-factory-abbrev Module SN,
 ].
-

--- a/structures.v
+++ b/structures.v
@@ -14,6 +14,8 @@ Register Coq.Init.Datatypes.Some as hb.some.
 Register Coq.Init.Datatypes.pair as hb.pair.
 Register Coq.Init.Datatypes.prod as hb.prod.
 Register Coq.Init.Specif.sigT as hb.sigT.
+Definition indexed {T} (x : T) := x.
+Register indexed as hb.indexed.
 
 Declare Scope HB_scope.
 Notation "{  A  'of'  P  &  ..  &  Q  }" :=
@@ -38,10 +40,26 @@ typeabbrev classname gref.
 typeabbrev factoryname gref.
 typeabbrev structure term.
 
+kind triple type -> type -> type -> type.
+type triple A -> B -> C -> triple A B C.
+typeabbrev (w-args A) (triple A (list term) term).
+
+kind w-params type -> type -> type.
+type w-params.cons name -> term -> (term -> w-params A) -> w-params A.
+type w-params.nil name -> term -> (term -> A) -> w-params A.
+
+typeabbrev (list-w-params A) (w-params (list (w-args A))).
+typeabbrev (one-w-params A) (w-params (w-args A)).
+
 % (class C S ML) represents a class C packed in S containing mixins ML.
-% The order of ML is relevant.
+% example
+%  class {{Module.axioms}} {{Module.type}}
+%    (w-params.cons {{Ring.type}} R \
+%     w-params.nil TheType \
+%          [..., pr3 {{Ring.mixin}} [] TheType,
+%                pr3 {{Module.mixin}} [R] TheType ])
 kind class type.
-type class classname -> structure -> list mixinname -> class.
+type class classname -> structure -> list-w-params mixinname -> class.
 
 %%%%%% Memory of joins %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -50,19 +68,23 @@ pred join o:classname, o:classname, o:classname.
 
 %%%%% Factories %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % [from FN MN F] invariant:
-% "F : forall T LMN, FN T .. -> MN T .." where
-%  - .. is a sub list of LMN
+% "F : forall p1 .. pn T LMN, FN p1 .. pn T LMN1 -> MN c1 .. cm T LMN2" where
+%  - LMN1 and LMN2 are sub lists of LMN
+%  - c1 .. cm are terms built using p1 .. pn and T
 % - [factory-requires FN LMN]
 % [from _ M _] tests whether M is a declared mixin.
 pred from o:factoryname, o:mixinname, o:term.
 
 % [factory-requires M ML] means that factory M depends on
 % (i.e. has parameters among) mixins ML.
-pred factory-requires o:factoryname, o:list mixinname.
+pred factory-requires o:factoryname, o:list-w-params mixinname.
 
 % [factory-constructor F K] means K is a constructor for
 % the factory F.
 pred factory-constructor o:factoryname, o:gref.
+
+% TODO params
+pred factory-nparams o:factoryname, o:int.
 
 % class-def contains all the classes ever declared
 pred class-def o:class.
@@ -131,14 +153,22 @@ pp-from (from F M T) :-
   coq.say "  " {coq.term->string T},
   coq.say "".
 
-pred pp-gref i:gref.
-pp-gref X :- coq.say "  " {coq.term->string (global X)}.
+pred pp-list-w-params i:list-w-params mixinname, i:term.
+pred pp-list-w-params.list-triple i:list (w-args mixinname), i:term.
+pred pp-list-w-params.triple i:w-args mixinname.
+pp-list-w-params (w-params.cons N Ty LwP) T :-
+  @pi-decl N Ty p\ pp-list-w-params (LwP p) {coq.mk-app T [p]}.
+pp-list-w-params (w-params.nil N TTy LwP) T :-
+  @pi-decl N TTy t\ pp-list-w-params.list-triple (LwP t) {coq.mk-app T [t]}.
+pp-list-w-params.list-triple L S :-
+  coq.say {coq.term->string S} ":=",
+  std.forall L pp-list-w-params.triple.
+pp-list-w-params.triple (triple M Params T) :-
+  coq.say "  " {coq.term->string (app [global M|{std.append Params [T]}])}.
 
 pred pp-class i:prop.
-pp-class (class-def (class _ S ML)) :-
-  coq.say {coq.term->string S} ":=",
-  std.forall ML pp-gref,
-  coq.say "".
+pp-class (class-def (class _ S MLwP)) :-
+  pp-list-w-params MLwP S.
 
 main [] :- !, std.do! [
   coq.say "--------------------- Hierarchy -----------------------------------",
@@ -213,29 +243,29 @@ Elpi Accumulate File "hb.elpi".
 Elpi Accumulate Db hb.db.
 Elpi Accumulate lp:{{
 
-pred product->grefs i:term, o:list gref, o:bool.
-product->grefs {{ lib:hb.prod lp:A lp:B  }} L ClosureCheck :- !,
-  product->grefs B GRB ClosureCheck,
-  product->grefs A GRA _,
+pred product->triples i:term, o:list (w-args factoryname), o:bool.
+product->triples  {{ lib:hb.prod lp:A lp:B  }} L ClosureCheck :- !,
+  product->triples B GRB ClosureCheck,
+  product->triples A GRA _,
   std.append GRA GRB L.
-product->grefs {{ True }} [] tt :- !.
-product->grefs {{ False }} [] ff :- !.
-product->grefs A [GR] tt :-
-  type->gref A GR.
+product->triples {{ True }} [] tt :- !.
+product->triples {{ False }} [] ff :- !.
+product->triples A [GR] tt :- factory? A GR.
 
-pred type->gref i:term, o:gref.
-type->gref (app[global Abbrev|_]) GR :- phant-abbrev GR Abbrev _.
-type->gref (app[global GR|_]) GR :- !.
-type->gref T _ :- coq.error "Not a factory:" {coq.term->string T}.
+pred sigT->list-w-params i:term, o:list-w-params factoryname, o:bool.
+sigT->list-w-params (fun N T B) L C :-
+  L = w-params.cons N T Rest,
+  @pi-decl N T p\
+    sigT->list-w-params (B p) (Rest p) C.
+sigT->list-w-params {{ lib:@hb.sigT _ lp:{{ fun N Ty B }} }} L C :-
+  L = w-params.nil N Ty Rest,
+  @pi-decl N Ty t\
+    product->triples (B t) (Rest t) C.
 
-pred sigT->grefs i:term, o:list gref, o:bool.
-sigT->grefs {{ lib:@hb.sigT _ (fun a : lp:T => lp:(B a)) }} L S :-
-  @pi-decl `a` T a\
-    product->grefs (B a) L S.
-
-main [const-decl Module (some B) _] :- !,
-  sigT->grefs B GRFS ClosureCheck, !,
-  with-attributes (main-declare-structure Module GRFS ClosureCheck).
+main [const-decl Module (some B) _] :- !, std.do! [
+  sigT->list-w-params B GRFS ClosureCheck, !,
+  with-attributes (main-declare-structure Module GRFS ClosureCheck),
+].
 main _ :- coq.error "Usage: HB.structure Definition <ModuleName> := { A of <Factory1> A & … & <FactoryN> A }".
 }}.
 Elpi Typecheck.
@@ -251,12 +281,10 @@ Elpi Export HB.structure.
     Syntax for declaring a canonical instance:
 
     <<
-    Definition f1 : Factory1 T := Factory1.Build T …
-    …
-    Definition fN : FactoryN T := FactoryN.Build T …
-    HB.instance T f1 … fN.
+    Definition f Params : Factory T := Factory.Build Params T …
+    HB.instance Params T f.
 
-    HB.instance Definition N := Factory.Build T …
+    HB.instance Definition N Params := Factory.Build Params T …
     >>
 
 *)
@@ -265,6 +293,7 @@ Elpi Command HB.instance.
 Elpi Accumulate File "hb.elpi".
 Elpi Accumulate Db hb.db.
 Elpi Accumulate lp:{{
+
 main [const-decl Name (some Body) TyWP] :- !, std.do! [
   coq.arity->term TyWP Ty,
   std.assert-ok! (coq.typecheck Body Ty) "Definition illtyped",
@@ -272,10 +301,12 @@ main [const-decl Name (some Body) TyWP] :- !, std.do! [
   std.assert! (factory-builder-nparams Builder NParams) "Not a factory builder synthesized by HB",
   coq.env.add-const Name Body Ty ff ff C,
   std.appendR {coq.mk-n-holes NParams} [T|_] Args,
-  with-attributes (main-declare-canonical-instances T [global (const C)]),
+  with-attributes (main-declare-canonical-instances T (global (const C))),
 ].
-main [S|FIS] :- std.map [S|FIS] argument->term [T|FIL], !,
-  with-attributes (main-declare-canonical-instances T FIL).
+main L :-
+  std.map L argument->term [T,F], !,
+  with-attributes
+    (main-declare-canonical-instances T F).
 main _ :- coq.error "Usage: HB.instance <CarrierTerm> <FactoryInstanceTerm>*\nUsage: HB.instance Definition <Name> := <Builder> T ...".
 
 }}.

--- a/structures.v
+++ b/structures.v
@@ -297,11 +297,18 @@ Elpi Accumulate lp:{{
 main [const-decl Name (some Body) TyWP] :- !, std.do! [
   coq.arity->term TyWP Ty,
   std.assert-ok! (coq.typecheck Body Ty) "Definition illtyped",
-  std.assert! (coq.safe-dest-app Body (global (const Builder)) Args) "Not an application of a builder, use a section if you have parameters",
+
+  SectionName is "hb_instance_" ^ {term_to_string {new_int} },
+  coq.env.begin-section SectionName,
+  postulate-arity TyWP [] Body SectionBody,
+
+  std.assert! (coq.safe-dest-app SectionBody (global (const Builder)) Args) "Not an application of a builder, use a section if you have parameters",
   std.assert! (factory-builder-nparams Builder NParams) "Not a factory builder synthesized by HB",
-  coq.env.add-const Name Body Ty ff ff C,
+  coq.env.add-const Name SectionBody _ ff ff C,
   std.appendR {coq.mk-n-holes NParams} [T|_] Args,
   with-attributes (main-declare-canonical-instances T (global (const C))),
+
+  coq.env.end-section,
 ].
 main L :-
   std.map L argument->term [T,F], !,


### PR DESCRIPTION
```coq
HB.mixin Record (P1 : T1) ... (A : Type) foo of f1 P1 A & .. & f2 P1 (P1 * P2) A := {
  ...
}.
```

The key is to represent the dispatching a factory does of its parameters to the underlying mixins.
Here for example here `foo P1 ..` passes `P1` to `f1` and `P1`, `P1 * P2` to `f2`.
A dispatching is an arbitrary function from parameters to a list of parameters.
The code base has a new data type `list-w-params A` and `w-params A` to represent it.

Fix #75 
