### PR TITLE
Factory fields now mask lemmas and operators by default

### DIFF
--- a/demo1/hierarchy_1.v
+++ b/demo1/hierarchy_1.v
@@ -50,12 +50,12 @@ HB.factory Record Ring_of_TYPE A := {
 HB.builders Context A (a : Ring_of_TYPE A).
 
   Definition to_AddComoid_of_TYPE :=
-    AddComoid_of_TYPE.Build A zero_a add_a addrA_a addrC_a add0r_a.
+    AddComoid_of_TYPE.Build A zero add addrA addrC add0r.
   HB.instance A to_AddComoid_of_TYPE.
 
   Definition to_Ring_of_AddComoid :=
-    Ring_of_AddComoid.Build A _ _ _ addNr_a mulrA_a mul1r_a
-      mulr1_a mulrDl_a mulrDr_a.
+    Ring_of_AddComoid.Build A _ _ _ addNr mulrA mul1r
+      mulr1 mulrDl mulrDr.
   HB.instance A to_Ring_of_AddComoid.
 
 HB.end.

--- a/demo1/hierarchy_2.v
+++ b/demo1/hierarchy_2.v
@@ -35,11 +35,11 @@ HB.factory Record AddAG_of_TYPE A := {
 HB.builders Context A (a : AddAG_of_TYPE A).
 
   Definition to_AddComoid_of_TYPE :=
-    AddComoid_of_TYPE.Build A zero_a add_a addrA_a addrC_a add0r_a.
+    AddComoid_of_TYPE.Build A zero add addrA addrC add0r.
   HB.instance A to_AddComoid_of_TYPE.
 
   Definition to_AddAG_of_AddComoid :=
-    AddAG_of_AddComoid.Build A _ addNr_a.
+    AddAG_of_AddComoid.Build A _ addNr.
   HB.instance A to_AddAG_of_AddComoid.
 
 HB.end.
@@ -68,11 +68,11 @@ HB.factory Record Ring_of_AddComoid A of AddComoid A := {
 
 HB.builders Context A (a : Ring_of_AddComoid A).
 
-  Definition to_AddAG_of_AddComoid := AddAG_of_AddComoid.Build A _ addNr_a.
+  Definition to_AddAG_of_AddComoid := AddAG_of_AddComoid.Build A _ addNr.
   HB.instance A to_AddAG_of_AddComoid.
 
   Definition to_Ring_of_AddAG := Ring_of_AddAG.Build A
-    _ _ mulrA_a mul1r_a mulr1_a mulrDl_a mulrDr_a.
+    _ _ mulrA mul1r mulr1 mulrDl mulrDr.
   HB.instance A to_Ring_of_AddAG.
 
 HB.end.
@@ -99,11 +99,11 @@ HB.factory Record Ring_of_TYPE A := {
 HB.builders Context A (a : Ring_of_TYPE A).
 
   Definition to_AddComoid_of_TYPE := AddComoid_of_TYPE.Build A
-    zero_a add_a addrA_a addrC_a add0r_a.
+    zero add addrA addrC add0r.
   HB.instance A to_AddComoid_of_TYPE.
 
   Definition to_Ring_of_AddComoid := Ring_of_AddComoid.Build A
-    _ _ _ addNr_a mulrA_a mul1r_a mulr1_a mulrDl_a mulrDr_a.
+    _ _ _ addNr mulrA mul1r mulr1 mulrDl mulrDr.
   HB.instance A to_Ring_of_AddComoid.
 HB.end.
 

--- a/demo1/hierarchy_3.v
+++ b/demo1/hierarchy_3.v
@@ -35,10 +35,10 @@ HB.factory Record AddAG_of_TYPE A := {
 HB.builders Context A (a : AddAG_of_TYPE A).
 
   Definition to_AddComoid_of_TYPE := AddComoid_of_TYPE.Build A
-    zero_a add_a addrA_a addrC_a add0r_a.
+    zero add addrA addrC add0r.
   HB.instance A to_AddComoid_of_TYPE.
 
-  Definition to_AddAG_of_AddComoid := AddAG_of_AddComoid.Build A _ addNr_a.
+  Definition to_AddAG_of_AddComoid := AddAG_of_AddComoid.Build A _ addNr.
   HB.instance A to_AddAG_of_AddComoid.
 HB.end.
 HB.structure Definition AddAG := { A of AddAG_of_TYPE A }.
@@ -70,23 +70,23 @@ HB.factory Record Ring_of_AddAG A of AddAG A := {
 
 HB.builders Context A (a : Ring_of_AddAG A).
 
-  Fact mul0r : left_zero zero mul_a.
+  Fact mul0r : left_zero zero mul.
   Proof.
   move=> x; rewrite -[LHS]add0r addrC.
-  rewrite -{2}(addNr (mul_a x x)) (addrC (opp _)) addrA.
-  by rewrite -mulrDl_a add0r addrC addNr.
+  rewrite -{2}(addNr (mul x x)) (addrC (opp _)) addrA.
+  by rewrite -mulrDl add0r addrC addNr.
   Qed.
 
-  Fact mulr0 : right_zero zero mul_a.
+  Fact mulr0 : right_zero zero mul.
   Proof.
   move=> x; rewrite -[LHS]add0r addrC.
-  rewrite -{2}(addNr (mul_a x x)) (addrC (opp _)) addrA.
-  by rewrite -mulrDr_a add0r addrC addNr.
+  rewrite -{2}(addNr (mul x x)) (addrC (opp _)) addrA.
+  by rewrite -mulrDr add0r addrC addNr.
   Qed.
 
   Definition to_SemiRing_of_AddComoid := SemiRing_of_AddComoid.Build A
-    _ mul_a mulrA_a mulr1_a mul1r_a
-    mulrDl_a mulrDr_a mul0r mulr0.
+    _ mul mulrA mulr1 mul1r
+    mulrDl mulrDr mul0r mulr0.
   HB.instance A to_SemiRing_of_AddComoid.
 
 HB.end.
@@ -106,11 +106,11 @@ HB.factory Record Ring_of_AddComoid A of AddComoid A := {
 
 HB.builders Context A (a : Ring_of_AddComoid A).
 
-  Definition to_AddAG_of_AddComoid := AddAG_of_AddComoid.Build A _ addNr_a.
+  Definition to_AddAG_of_AddComoid := AddAG_of_AddComoid.Build A _ addNr.
   HB.instance A to_AddAG_of_AddComoid.
 
   Definition to_Ring_of_AddAG := Ring_of_AddAG.Build A
-    _ _ mulrA_a mul1r_a mulr1_a mulrDl_a mulrDr_a.
+    _ _ mulrA mul1r mulr1 mulrDl mulrDr.
   HB.instance A to_Ring_of_AddAG.
 
 HB.end.
@@ -137,11 +137,11 @@ HB.factory Record Ring_of_TYPE A := {
 HB.builders Context A (a : Ring_of_TYPE A).
 
   Definition to_AddComoid_of_TYPE := AddComoid_of_TYPE.Build A
-    zero_a add_a addrA_a addrC_a add0r_a.
+    zero add addrA addrC add0r.
   HB.instance A to_AddComoid_of_TYPE.
 
   Definition to_Ring_of_AddComoid := Ring_of_AddComoid.Build A
-    _ _ _ addNr_a mulrA_a mul1r_a mulr1_a mulrDl_a mulrDr_a.
+    _ _ _ addNr mulrA mul1r mulr1 mulrDl mulrDr.
   HB.instance A to_Ring_of_AddComoid.
 HB.end.
 

--- a/demo1/hierarchy_4.v
+++ b/demo1/hierarchy_4.v
@@ -32,15 +32,15 @@ HB.factory Record AddComoid_of_TYPE A := {
 
 HB.builders Context A (a : AddComoid_of_TYPE A).
 
-  Fact addr0 : right_id zero_a add_a.
-  Proof. by move=> x; rewrite addrC_a add0r_a. Qed.
+  Fact addr0 : right_id zero add.
+  Proof. by move=> x; rewrite addrC add0r. Qed.
 
   Definition to_AddMonoid_of_TYPE :=
-    AddMonoid_of_TYPE.Build A zero_a add_a addrA_a add0r_a addr0.
+    AddMonoid_of_TYPE.Build A zero add addrA add0r addr0.
   HB.instance A to_AddMonoid_of_TYPE.
 
   Definition to_AddComoid_of_AddMonoid :=
-    AddComoid_of_AddMonoid.Build A addrC_a.
+    AddComoid_of_AddMonoid.Build A addrC.
   HB.instance A to_AddComoid_of_AddMonoid.
 HB.end.
 HB.structure Definition AddComoid := { A of AddComoid_of_TYPE A }.
@@ -64,11 +64,11 @@ HB.factory Record AddAG_of_TYPE A := {
 HB.builders Context A (a : AddAG_of_TYPE A).
 
   Definition to_AddComoid_of_TYPE :=
-    AddComoid_of_TYPE.Build A zero_a add_a addrA_a addrC_a add0r_a.
+    AddComoid_of_TYPE.Build A zero add addrA addrC add0r.
   HB.instance A to_AddComoid_of_TYPE.
 
   Definition to_AddAG_of_AddComoid :=
-    AddAG_of_AddComoid.Build A _ addNr_a.
+    AddAG_of_AddComoid.Build A _ addNr.
   HB.instance A to_AddAG_of_AddComoid.
 HB.end.
 HB.structure Definition AddAG := { A of AddAG_of_TYPE A }.
@@ -98,23 +98,23 @@ HB.factory Record Ring_of_AddAG A of AddAG A := {
 
 HB.builders Context A (a : Ring_of_AddAG A).
 
-  Fact mul0r : left_zero zero mul_a.
+  Fact mul0r : left_zero zero mul.
   Proof.
   move=> x; rewrite -[LHS]add0r addrC.
-  rewrite -{2}(addNr (mul_a x x)) (addrC (opp _)) addrA.
-  by rewrite -mulrDl_a add0r addrC addNr.
+  rewrite -{2}(addNr (mul x x)) (addrC (opp _)) addrA.
+  by rewrite -mulrDl add0r addrC addNr.
   Qed.
 
-  Fact mulr0 : right_zero zero mul_a.
+  Fact mulr0 : right_zero zero mul.
   Proof.
   move=> x; rewrite -[LHS]add0r addrC.
-  rewrite -{2}(addNr (mul_a x x)) (addrC (opp _)) addrA.
-  by rewrite -mulrDr_a add0r addrC addNr.
+  rewrite -{2}(addNr (mul x x)) (addrC (opp _)) addrA.
+  by rewrite -mulrDr add0r addrC addNr.
   Qed.
 
   Definition to_SemiRing_of_AddComoid :=
-    SemiRing_of_AddComoid.Build A _ mul_a mulrA_a mulr1_a mul1r_a
-      mulrDl_a mulrDr_a (mul0r) (mulr0).
+    SemiRing_of_AddComoid.Build A _ mul mulrA mulr1 mul1r
+      mulrDl mulrDr (mul0r) (mulr0).
   HB.instance A to_SemiRing_of_AddComoid.
 HB.end.
 
@@ -133,11 +133,11 @@ HB.factory Record Ring_of_AddComoid A of AddComoid A := {
 
 HB.builders Context A (a : Ring_of_AddComoid A).
 
-  Definition to_AddAG_of_AddComoid := AddAG_of_AddComoid.Build A _ addNr_a.
+  Definition to_AddAG_of_AddComoid := AddAG_of_AddComoid.Build A _ addNr.
   HB.instance A to_AddAG_of_AddComoid.
 
   Definition to_Ring_of_AddAG := Ring_of_AddAG.Build A
-    _ _ mulrA_a mul1r_a mulr1_a mulrDl_a mulrDr_a.
+    _ _ mulrA mul1r mulr1 mulrDl mulrDr.
   HB.instance A to_Ring_of_AddAG.
 
 HB.end.
@@ -164,11 +164,11 @@ HB.factory Record Ring_of_TYPE A := {
 HB.builders Context A (a : Ring_of_TYPE A).
 
   Definition to_AddComoid_of_TYPE := AddComoid_of_TYPE.Build A
-    zero_a add_a addrA_a addrC_a add0r_a.
+    zero add addrA addrC add0r.
   HB.instance A to_AddComoid_of_TYPE.
 
   Definition to_Ring_of_AddComoid := Ring_of_AddComoid.Build A
-    _ _ _ addNr_a mulrA_a mul1r_a mulr1_a mulrDl_a mulrDr_a.
+    _ _ _ addNr mulrA mul1r mulr1 mulrDl mulrDr.
   HB.instance A to_Ring_of_AddComoid.
 HB.end.
 

--- a/demo1/hierarchy_5.v
+++ b/demo1/hierarchy_5.v
@@ -31,15 +31,15 @@ HB.factory Record AddComoid_of_TYPE A := {
 
 HB.builders Context A (a : AddComoid_of_TYPE A).
 
-  Fact addr0 : right_id zero_a add_a.
-  Proof. by move=> x; rewrite addrC_a add0r_a. Qed.
+  Fact addr0 : right_id zero add.
+  Proof. by move=> x; rewrite addrC add0r. Qed.
 
   Definition to_AddMonoid_of_TYPE :=
-    AddMonoid_of_TYPE.Build A zero_a add_a addrA_a add0r_a addr0.
+    AddMonoid_of_TYPE.Build A zero add addrA add0r addr0.
   HB.instance A to_AddMonoid_of_TYPE.
 
   Definition to_AddComoid_of_AddMonoid :=
-    AddComoid_of_AddMonoid.Build A addrC_a.
+    AddComoid_of_AddMonoid.Build A addrC.
   HB.instance A to_AddComoid_of_AddMonoid.
 HB.end.
 HB.structure Definition AddComoid := { A of AddComoid_of_TYPE A }.
@@ -63,11 +63,11 @@ HB.factory Record AddAG_of_TYPE A := {
 HB.builders Context A (a : AddAG_of_TYPE A).
 
   Definition to_AddComoid_of_TYPE :=
-    AddComoid_of_TYPE.Build A zero_a add_a addrA_a addrC_a add0r_a.
+    AddComoid_of_TYPE.Build A zero add addrA addrC add0r.
   HB.instance A to_AddComoid_of_TYPE.
 
   Definition to_AddAG_of_AddComoid :=
-    AddAG_of_AddComoid.Build A _ addNr_a.
+    AddAG_of_AddComoid.Build A _ addNr.
   HB.instance A to_AddAG_of_AddComoid.
 HB.end.
 HB.structure Definition AddAG := { A of AddAG_of_TYPE A }.
@@ -113,22 +113,22 @@ HB.factory Record Ring_of_AddAG A of AddAG A := {
 
 HB.builders Context A (a : Ring_of_AddAG A).
 
-  Fact mul0r : left_zero zero mul_a.
+  Fact mul0r : left_zero zero mul.
   Proof.
   move=> x; rewrite -[LHS]add0r addrC.
-  rewrite -{2}(addNr (mul_a x x)) (addrC (opp _)) addrA.
-  by rewrite -mulrDl_a add0r addrC addNr.
+  rewrite -{2}(addNr (mul x x)) (addrC (opp _)) addrA.
+  by rewrite -mulrDl add0r addrC addNr.
   Qed.
 
-  Fact mulr0 : right_zero zero mul_a.
+  Fact mulr0 : right_zero zero mul.
   Proof.
   move=> x; rewrite -[LHS]add0r addrC.
-  rewrite -{2}(addNr (mul_a x x)) (addrC (opp _)) addrA.
-  by rewrite -mulrDr_a add0r addrC addNr.
+  rewrite -{2}(addNr (mul x x)) (addrC (opp _)) addrA.
+  by rewrite -mulrDr add0r addrC addNr.
   Qed.
 
   Definition to_SemiRing_of_AddComoid := SemiRing_of_AddComoid.Build A
-    _ mul_a mulrA_a mulr1_a mul1r_a mulrDl_a mulrDr_a mul0r mulr0.
+    _ mul mulrA mulr1 mul1r mulrDl mulrDr mul0r mulr0.
   HB.instance A to_SemiRing_of_AddComoid.
 
 HB.end.
@@ -147,11 +147,11 @@ HB.factory Record Ring_of_AddComoid A of AddComoid A := {
 
 HB.builders Context A (a :Ring_of_AddComoid A).
 
-  Definition to_AddAG_of_AddComoid := AddAG_of_AddComoid.Build A _ addNr_a.
+  Definition to_AddAG_of_AddComoid := AddAG_of_AddComoid.Build A _ addNr.
   HB.instance A to_AddAG_of_AddComoid.
 
   Definition to_Ring_of_AddAG := Ring_of_AddAG.Build A
-    _ _ mulrA_a mul1r_a mulr1_a mulrDl_a mulrDr_a.
+    _ _ mulrA mul1r mulr1 mulrDl mulrDr.
   HB.instance A to_Ring_of_AddAG.
 
 HB.end.
@@ -176,11 +176,11 @@ HB.factory Record Ring_of_TYPE A := {
 HB.builders Context A (a : Ring_of_TYPE A).
 
   Definition to_AddComoid_of_TYPE := AddComoid_of_TYPE.Build A
-    zero_a add_a addrA_a addrC_a add0r_a.
+    zero add addrA addrC add0r.
   HB.instance A to_AddComoid_of_TYPE.
 
   Definition to_Ring_of_AddComoid := Ring_of_AddComoid.Build A
-    _ _ _ addNr_a mulrA_a mul1r_a mulr1_a mulrDl_a mulrDr_a.
+    _ _ _ addNr mulrA mul1r mulr1 mulrDl mulrDr.
   HB.instance A to_Ring_of_AddComoid.
 HB.end.
 

--- a/demo2/stage10.v
+++ b/demo2/stage10.v
@@ -107,11 +107,11 @@ HB.factory Record Ring_of_TYPE A := {
 HB.builders Context A (a : Ring_of_TYPE A).
 
 Definition to_AddAG_of_TYPE := AddAG_of_TYPE.Build A
-    _ _ _ addrA_a addrC_a add0r_a addNr_a.
+    _ _ _ addrA addrC add0r addNr.
   HB.instance A to_AddAG_of_TYPE.
   Definition to_Ring_of_AddAG :=
-    Ring_of_AddAG.Build _ _ _ mulrA_a mul1r_a
-      mulr1_a mulrDl_a mulrDr_a.
+    Ring_of_AddAG.Build _ _ _ mulrA mul1r
+      mulr1 mulrDl mulrDr.
   HB.instance A to_Ring_of_AddAG.
 HB.end.
 
@@ -141,11 +141,11 @@ HB.factory Record TopologicalBase T := {
 HB.builders Context T (a : TopologicalBase T).
 
   Definition open_of : (T -> Prop) -> Prop :=
-    [set A | exists2 D, D `<=` open_base_a & A = \bigcup_(X in D) X].
+    [set A | exists2 D, D `<=` open_base & A = \bigcup_(X in D) X].
 
   Lemma open_of_setT : open_of setT.  Proof.
-  exists open_base_a; rewrite // predeqE => x; split=> // _.
-  by apply: open_base_covers_a.
+  exists open_base; rewrite // predeqE => x; split=> // _.
+  by apply: open_base_covers.
   Qed.
 
   Lemma open_of_bigcup {I} (D : set I) (F : I -> set T) :

--- a/demo2/stage11.v
+++ b/demo2/stage11.v
@@ -111,11 +111,11 @@ HB.factory Record Ring_of_TYPE A := {
 HB.builders Context A (a : Ring_of_TYPE A).
 
   Definition to_AddAG := AddAG_of_TYPE.Build A
-    _ _ _ addrA_a addrC_a add0r_a addNr_a.
+    _ _ _ addrA addrC add0r addNr.
   HB.instance A to_AddAG.
 
   Definition to_Ring := Ring_of_AddAG.Build A
-    _ _ mulrA_a mul1r_a mulr1_a mulrDl_a mulrDr_a.
+    _ _ mulrA mul1r mulr1 mulrDl mulrDr.
   HB.instance A to_Ring.
 HB.end.
 
@@ -145,12 +145,12 @@ HB.factory Record TopologicalBase T := {
 HB.builders Context T (a : TopologicalBase T).
 
   Definition open_of :=
-    [set A | exists2 D, D `<=` open_base_a & A = \bigcup_(X in D) X].
+    [set A | exists2 D, D `<=` open_base & A = \bigcup_(X in D) X].
 
   Lemma open_of_setT : open_of setT.
   Proof.
-  exists open_base_a; rewrite // predeqE => x; split=> // _.
-  by apply: open_base_covers_a.
+  exists open_base; rewrite // predeqE => x; split=> // _.
+  by apply: open_base_covers.
   Qed.
 
   Lemma open_of_bigcup {I} (D : set I) (F : I -> set T) :

--- a/demo3/hierarchy_1.v
+++ b/demo3/hierarchy_1.v
@@ -44,12 +44,12 @@ HB.factory Record Ring_of_MulMonoid A of MulMonoid A := {
 HB.builders Context A (a : Ring_of_MulMonoid A).
 
   Definition to_AddMonoid_of_Type :=
-    AddMonoid_of_Type.Build A zero_a add_a addrA_a add0r_a addr0_a.
+    AddMonoid_of_Type.Build A zero add addrA add0r addr0.
 
   HB.instance A to_AddMonoid_of_Type.
 
   Definition to_Ring_of_AddMulMonoid :=
-    Ring_of_AddMulMonoid.Build A opp_a addrC_a addNr_a mulrDl_a mulrDr_a.
+    Ring_of_AddMulMonoid.Build A opp addrC addNr mulrDl mulrDr.
 
   HB.instance A to_Ring_of_AddMulMonoid.
 

--- a/demo3/hierarchy_2.v
+++ b/demo3/hierarchy_2.v
@@ -43,12 +43,12 @@ HB.factory Record Ring_of_AddMulMonoid A of MulMonoid A & AddMonoid A := {
 HB.builders Context A (a : Ring_of_AddMulMonoid A).
 
   Definition to_AbGroup_of_AddMonoid :=
-    AbGroup_of_AddMonoid.Build A opp_a addrC_a addNr_a.
+    AbGroup_of_AddMonoid.Build A opp addrC addNr.
 
   HB.instance A to_AbGroup_of_AddMonoid.
 
   Definition to_Ring_of_AbGroupMulMonoid :=
-  Ring_of_AbGroupMulMonoid.Build A mulrDl_a mulrDr_a.
+  Ring_of_AbGroupMulMonoid.Build A mulrDl mulrDr.
 
   HB.instance A to_Ring_of_AbGroupMulMonoid.
 
@@ -70,17 +70,17 @@ HB.factory Record Ring_of_MulMonoid A of MulMonoid A := {
 HB.builders Context A (a : Ring_of_MulMonoid A).
 
   Definition to_AddMonoid_of_Type :=
-    AddMonoid_of_Type.Build A zero_a add_a addrA_a add0r_a addr0_a.
+    AddMonoid_of_Type.Build A zero add addrA add0r addr0.
 
   HB.instance A to_AddMonoid_of_Type.
 
   Definition to_AbGroup_of_AddMonoid :=
-    AbGroup_of_AddMonoid.Build A opp_a addrC_a addNr_a.
+    AbGroup_of_AddMonoid.Build A opp addrC addNr.
 
   HB.instance A to_AbGroup_of_AddMonoid.
 
   Definition to_Ring_of_AddMulMonoid :=
-    Ring_of_AddMulMonoid.Build A opp_a addrC_a addNr_a mulrDl_a mulrDr_a.
+    Ring_of_AddMulMonoid.Build A opp addrC addNr mulrDl mulrDr.
 
   HB.instance A to_Ring_of_AddMulMonoid.
 

--- a/hb.elpi
+++ b/hb.elpi
@@ -807,7 +807,7 @@ mk-mixin-fun T ML X MLX :- mk-mixin-fun.then T ML (body\ body = X) MLX.
 
 pred clean-op-ty i:list prop, i:term, i:term, i:term, o:term.
 clean-op-ty [] _ _ T1 T2 :- copy T1 T2.
-clean-op-ty [exported-op Po C|Ops] SortPTheStructure TheStructure T1 T2 :-
+clean-op-ty [exported-op _ Po C|Ops] SortPTheStructure TheStructure T1 T2 :-
   gr-deps (const Po) ML,
   mk-mixin-fun SortPTheStructure ML (app [global (const C), TheStructure]) EtaC,
   (pi L T R H S\
@@ -818,10 +818,9 @@ clean-op-ty [exported-op Po C|Ops] SortPTheStructure TheStructure T1 T2 :-
 % same operation out of the package structure (out of the class field of the
 % structure). We also provide all the other mixin dependencies (other misins)
 % of the package structure.
-pred exported-op o:constant, o:constant. % memory
-pred export-1-operation i:term, i:term, i:term, i:option constant, i:list prop, o:list prop.
-export-1-operation _ _ _ none EX EX :- !. % not a projection, no operation
-export-1-operation Struct Psort Pclass (some Poperation) EXI EXO :- !, std.do! [
+pred export-1-operation i:mixinname, i:term, i:term, i:term, i:option constant, i:list prop, o:list prop.
+export-1-operation _ _ _ _ none EX EX :- !. % not a projection, no operation
+export-1-operation M Struct Psort Pclass (some Poperation) EXI EXO :- !, std.do! [
   coq.gref->id (const Poperation) Name,
   (@pi-decl `s` Struct s\ sigma Carrier Class MSL DirtyTy Copies\ std.do! [
       Carrier = app[Psort, s],
@@ -839,25 +838,34 @@ export-1-operation Struct Psort Pclass (some Poperation) EXI EXO :- !, std.do! [
 
   coq.env.add-const Name T Ty ff ff C,
   coq.arguments.set-implicit (const C) [[maximal]] tt,
-  EXO = [exported-op Poperation C|EXI]
+  EXO = [exported-op M Poperation C|EXI]
 ].
 
 % Given a list of mixins, it exports all operations in there
-pred export-operations.aux i:term, i:term, i:term, i:list mixinname.
-export-operations.aux _ _ _ [].
-export-operations.aux Struct ProjSort ProjClass [indt M|ML] :- !, std.do! [
+pred export-operations.aux i:term, i:term, i:term, i:list mixinname, i:list prop, o:list prop.
+export-operations.aux _ _ _ [] EX EX.
+export-operations.aux Struct ProjSort ProjClass [indt M|ML] EX1 EX3 :- !, std.do! [
   coq.CS.canonical-projections M Poperations,
-  std.fold Poperations [] (export-1-operation Struct ProjSort ProjClass) _,
-  export-operations.aux Struct ProjSort ProjClass ML
+  std.fold Poperations EX1 (export-1-operation (indt M) Struct ProjSort ProjClass) EX2,
+  export-operations.aux Struct ProjSort ProjClass ML EX2 EX3
 ].
-export-operations.aux Struct ProjSort ProjClass [GR|ML] :-
+export-operations.aux Struct ProjSort ProjClass [GR|ML] EXI EXO:-
   coq.say GR "is not a record: skipping operations factory this mixin",
-  export-operations.aux Struct ProjSort ProjClass ML.
+  export-operations.aux Struct ProjSort ProjClass ML EXI EXO.
 
-pred export-operations i:term, i:term, i:term, i:list mixinname, o:list mixinname.
-export-operations Structure ProjSort ProjClass ML MLToExport :-
-  std.filter ML (m\not(mixin-first-class m _)) MLToExport,
-  export-operations.aux Structure ProjSort ProjClass MLToExport.
+pred export-operations i:term, i:term, i:term, i:list mixinname, i:list prop, o:list prop, o:list mixinname.
+export-operations Structure ProjSort ProjClass ML EXI EXO MLToExport :-
+  std.filter ML (m\ not(mixin-first-class m _)) MLToExport,
+  export-operations.aux Structure ProjSort ProjClass MLToExport EXI EXO.
+
+pred reexport-1-operation i:prop.
+reexport-1-operation (exported-op _M _P C) :-
+  add-abbrev {coq.gref->id (const C)} 0 (global (const C)) tt ff _.
+pred reexport-operations i:list mixinname.
+reexport-operations ML :- std.do![
+  std.flatten {std.map ML (m\ std.findall (exported-op m Poperation_ C_))} PL,
+  std.forall PL reexport-1-operation
+].
 
 % [declare-coercion P1 P2 C1 C2] declares a structure and a class coercion
 % from C1 to C2 given P1 P2 the two projections from the structure of C1
@@ -1035,20 +1043,28 @@ main-declare-structure Module GRFS ClosureCheck :- std.do! [
 
   coq.env.begin-module "Exports" none,
   declare-sort-coercion Structure SortProjection,
+  if-verbose (coq.say "HB: exporting operations"),
   ClassAlias => ClassRequires => Factories =>
-    export-operations Structure SortProjection ClassProjection ML MLToExport,
+    export-operations Structure SortProjection ClassProjection ML [] EX MLToExport,
+  if-verbose (coq.say "HB: exporting unification hints"),
   ClassAlias => ClassRequires => Factories =>
     declare-unification-hints SortProjection ClassProjection CurrentClass NewJoins,
   % Register in Elpi's DB the new structure
   % NOT TODO: All these acc are correctly locaed in an Export Module
-  std.forall MLToExport (m\
-     acc current (clause _ _ (mixin-first-class m ClassName))),
+  if-verbose (coq.say "HB: accumulating various props"),
+  std.forall MLToExport (m\  acc current (clause _ _ (mixin-first-class m ClassName))),
+  std.forall EX (ex\ acc current (clause _ _ ex)),
   std.forall Factories (f\ acc current (clause _ _ f)),
   acc current (clause _ _ ClassRequires),
   acc current (clause _ _ ClassAlias),
   std.forall NewJoins (j\ acc current (clause _ _ j)),
   acc current (clause _ _ (class-def CurrentClass)),
+
+  if-verbose (coq.say "HB: stop module Exports"),
   coq.env.end-module Exports,
+
+  if-verbose (coq.say "HB: reexporting previous operations as notations"),
+  EX => reexport-operations ML,
 
   coq.env.end-module _,
 
@@ -1157,9 +1173,7 @@ define-factory-operation TheType TheFactory NHoles (some P) :-
   T = app[global (const P), TheType|Holes_Factory],
   std.assert-ok! (coq.typecheck T _) "Illtyped applied factory operation",
   coq.gref->id (const P) Name,
-  coq.gref->id {term->gref TheFactory} F,
-  OpName is Name ^ "_" ^ F,
-  add-abbrev OpName 0 T ff ff _.
+  add-abbrev Name 0 T ff ff _.
 
 pred builders-postulate-factories i:context-decl, i:term, i:list mixinname.
 builders-postulate-factories (context-item ID T none _\ context-end) TheType GRML :- std.do! [

--- a/structures.v
+++ b/structures.v
@@ -106,6 +106,8 @@ kind builder type.
 type builder int -> factoryname -> term -> builder.
 pred builder-decl o:builder.
 
+pred exported-op o:mixinname, o:constant, o:constant. % memory of exported operations
+
 }}.
 
 (* %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% *)


### PR DESCRIPTION
- former axioms can be recovered by prefixing with the module name,
- former theorems *cannot*, which causes major breakage when the library evolves.