### PR TITLE
In `HB.instance` force unification to extract the class instead of the second argument.

### DIFF
--- a/hb.elpi
+++ b/hb.elpi
@@ -570,7 +570,8 @@ get-canonical-mixins-of T S MSL :- std.do! [
   get-structure-sort-projection S Sort,
   std.assert-ok! (coq.unify-eq T (app [Sort, ST])) "HB: get-canonical-mixins-of: T = sort ST",
   % Hum, this unification problem is not super trivial. TODO replace by something simpler
-  std.assert-ok! (coq.unify-eq ST (app [_, _, C])) "HB: get-canonical-mixins-of: ST = _ _ C",
+  get-constructor S KS,
+  std.assert-ok! (coq.unify-eq ST (app [global KS, _, C])) "HB: get-canonical-mixins-of: ST = _ _ C",
   C = app [_, _ | MIL],
   std.map MIL (mixin-srcs T) MSLL,
   std.flatten MSLL MSL


### PR DESCRIPTION
E.g. in `Definition t a b := K (T a b) (C a b).` if you unify `t x y = _ _ c` you don't necessarily force the unfolding of `t` and `c` could get `y`, while with `t x y = K _ c` you do, since the RHS is a rigid HNF hence the LHS must be reduces to expose `K` and `c` gets `C x y`