### PR TITLE
[instance] typecheck the type first

### DIFF
--- a/structures.v
+++ b/structures.v
@@ -303,6 +303,7 @@ Elpi Accumulate lp:{{
 
 main [const-decl Name (some Body) TyWP] :- !, std.do! [
   coq.arity->term TyWP Ty,
+  std.assert-ok! (coq.typecheck-ty Ty _) "Definition type illtyped",
   std.assert-ok! (coq.typecheck Body Ty) "Definition illtyped",
   if (TyWP = arity _) (
      % Do not open a section when it is not necessary (no parameters)


### PR DESCRIPTION
This seems like a big bug even if I don't undestand yet how it was working.
If you don't typecheck the type first, and pass it as the expected type of coq.typecheck, you get a unification problem like this one:
```
(monoid_of_semigroup.axioms_ M is_monoid_semigroup)   =?1=   
(monoid_of_semigroup.phant_axioms M ?e24 ?e26 (@id_phant ?e28 ?e30) 
   ?e32 (@id_phant ?e34 ?e36) ?e38 (@id_phant ?e40 ?e42)
   (@id_phant ?e44 ?e46))
```
Coq is able to solve it (in 8.11) without assigning the arguments of id_phant (only ?e24/26 IIRC). In 8.12 as well, but later on the system "realizes that".

I'm hesitating, coq.typecheck could typecheck the expect type if given before unifying it with the inferred one...
This fix makes sense anyway.