### PR TITLE
HB.instance understands #[local]

### DIFF
--- a/HB/common/log.compat.current.elpi
+++ b/HB/common/log.compat.current.elpi
@@ -85,7 +85,8 @@ coq.vernac->pp1 (notation KM NParams Term) (box (hv 2) [box h [str "Notation \"'
   coq.vernac->ppabbrterm NParams Term StrParams B.
 coq.vernac->pp1 (abbreviation Name NParams Term) (box (hv 2) [box h [str "Notation ",str Name|StrParams], str " :=", spc, B, str "."]) :-
   coq.vernac->ppabbrterm NParams Term StrParams B.
-coq.vernac->pp1 (canonical Name) (box h [str "Canonical ", str Name, str "."]).
+coq.vernac->pp1 (canonical Name Local) (box h [Locality, str "Canonical ", str Name, str "."]) :-
+  local->locality Local Locality.
 coq.vernac->pp1 (coercion Name SRC TGT) (box h [str "Coercion ", str Name, str " : ", str S, str " >-> ", str T, str "."]) :-
   coq.gref->path SRC SP, std.string.concat "." {std.take-last 2 SP} S,
   if2 (TGT = sortclass) (T = "Sortclass")
@@ -100,12 +101,17 @@ coq.vernac->pp1 (vernac.implicit Local Name [L]) (box h [Locality, str "Argument
   std.intersperse spc PP1 PP.
 coq.vernac->pp1 (comment A) (box (hov 2) [str"(*", str S, str"*)"]) :-
   std.any->string A S.
-coq.vernac->pp1 (check T) (box (hov 2) [str"Check", spc, PPT, str"."]) :-
-  @holes! => coq.term->pp T PPT.
+coq.vernac->pp1 (check T Fail) (box (hov 2) [Failure, str"Check", spc, PPT, str"."]) :-
+  @holes! => coq.term->pp T PPT,
+  fail->failure Fail Failure.
 
 pred local->locality i:bool, o:coq.pp.
 local->locality tt (str "Local ").
 local->locality ff (str "Global ").
+
+pred fail->failure i:bool, o:coq.pp.
+fail->failure tt (str "Fail ").
+fail->failure ff (str "").
 
 pred coq.vernac->ppimparg i:implicit_kind, o:coq.pp.
 coq.vernac->ppimparg explicit (str "_").

--- a/HB/common/log.elpi
+++ b/HB/common/log.elpi
@@ -112,9 +112,10 @@ coercion.declare C :- std.do! [
 % in the namespace, so we just define it here with the full name
 pred log.coq.CS.declare-instance i:constant.
 log.coq.CS.declare-instance C  :- std.do! [
+  if (@local!) (Local = tt) (Local = ff),
   coq.CS.declare-instance (const C),
   coq.gref->id (const C) Name,
-  log.private.log-vernac (log.private.coq.vernac.canonical Name),
+  log.private.log-vernac (log.private.coq.vernac.canonical Name Local),
 ].
 
 % Since "accumulate" is a keyword we can't use it as a predicate name
@@ -125,10 +126,11 @@ log.coq.env.accumulate S DB CL :- std.do! [
   if-verbose (log.private.log-vernac (log.private.coq.vernac.comment CL)),
 ].
 
-pred log.coq.check i:term, o:term, o:term.
-log.coq.check Skel Ty T :- std.do! [
-  std.assert-ok! (coq.elaborate-skeleton Skel Ty T) "Check fails",
-  log.private.log-vernac (log.private.coq.vernac.check Skel),
+pred log.coq.check i:term, o:term, o:term, o:diagnostic.
+log.coq.check Skel Ty T D :- std.do! [
+  coq.elaborate-skeleton Skel Ty T D,
+  if (get-option "fail" tt) (Fail = tt) (Fail = ff),
+  log.private.log-vernac (log.private.coq.vernac.check Skel Fail),
 ].
 
 namespace log.private {
@@ -163,10 +165,10 @@ type coq.vernac.inductive     indt-decl                     -> coq.vernac.
 type coq.vernac.abbreviation  string -> int -> term         -> coq.vernac.
 type coq.vernac.notation      string -> int -> term         -> coq.vernac.
 type coq.vernac.coercion      string -> gref -> class       -> coq.vernac.
-type coq.vernac.canonical     string                        -> coq.vernac.
+type coq.vernac.canonical     string -> bool                -> coq.vernac.
 type coq.vernac.implicit      bool -> string -> list (list implicit_kind)  -> coq.vernac.
 type coq.vernac.comment       A                             -> coq.vernac.
-type coq.vernac.check         term                          -> coq.vernac.
+type coq.vernac.check         term -> bool                  -> coq.vernac.
 
 }
 

--- a/HB/common/utils.elpi
+++ b/HB/common/utils.elpi
@@ -35,6 +35,8 @@ with-attributes P :-
     att "compress_coercions" bool,
     att "export" bool,
     att "skip" string,
+    att "local" bool,
+    att "fail" bool,
   ] Opts, !,
   Opts => P.
 
@@ -52,6 +54,11 @@ if-MC-compat P :- get-option "mathcomp.axiom" S, !,
   std.assert! (coq.locate S GR) "The name passed to the mathcomp.axiom attribute does not exist",
   P (some GR).
 if-MC-compat _.
+
+pred with-locality i:prop.
+with-locality P :-
+  if (get-option "local" tt) (A = @local!) (A = @global!),
+  A => P.
 
 % TODO: Should this only be used for gref that are factories? (and check in the first/second branch so?)
 % Should we make this an HO predicate, eg "located->gref S L is-factory? GR"

--- a/HB/instance.elpi
+++ b/HB/instance.elpi
@@ -98,7 +98,7 @@ declare-all T [class Class Struct MLwP|Rest] [pr Name CS|L] :-
   std.assert-ok! (coq.typecheck S STy) "declare-all: S illtyped",
 
   log.coq.env.add-const-noimplicits Name S STy @transparent! CS, % Bug coq/coq#11155, could be a Let
-  log.coq.CS.declare-instance CS, % Bug coq/coq#11155, should be local
+  with-locality (log.coq.CS.declare-instance CS), % Bug coq/coq#11155, should be local
   declare-all T Rest L.
 declare-all T [_|Rest] L :- declare-all T Rest L.
 declare-all _ [] [].
@@ -135,7 +135,7 @@ add-mixin T FGR MakeCanon MissinMixin [MixinSrcCl, BuiderDeclCl] :-
 
   std.assert! (MissinMixin = MixinName) "HB: anomaly: we built the wrong mixin",
 
-  % If the mixin instance is alreaduy a constant there is no need to
+  % If the mixin instance is already a constant there is no need to
   % alias it.
   if (Bo = global (const C)) true
     (Name is {nice-gref->string FGR} ^"_to_" ^ {nice-gref->string MixinName} ^ "__" ^ {std.any->string {new_int}},
@@ -143,7 +143,7 @@ add-mixin T FGR MakeCanon MissinMixin [MixinSrcCl, BuiderDeclCl] :-
      log.coq.env.add-const-noimplicits Name Bo Ty @transparent! C),
   if (MakeCanon = tt, whd (global (const C)) [] (global (indc _)) _)
      (if-verbose (coq.say "HB: declare canonical mixin instance" C),
-      log.coq.CS.declare-instance C)
+      with-locality (log.coq.CS.declare-instance C))
      true.
 
 pred add-all-mixins i:term, i:factoryname, i:list mixinname, i:bool, o:list prop.

--- a/_CoqProject.test-suite
+++ b/_CoqProject.test-suite
@@ -55,6 +55,7 @@ tests/exports.v
 tests/log_impargs_record.v
 tests/compress_coe.v
 tests/funclass.v
+tests/local_instance.v
 
 -R tests HB.tests
 -R examples HB.examples

--- a/tests/local_instance.v
+++ b/tests/local_instance.v
@@ -1,0 +1,12 @@
+From HB Require Import structures.
+
+HB.mixin Record def A := { default : A }.
+HB.structure Definition nonempty := { T of def T }.
+
+Section Box.
+  #[local] HB.instance Definition def_nat := def.Build nat 1.
+  Check default : nat.
+End Box.
+
+#[fail, skip="8.11"]
+HB.check (default : nat).


### PR DESCRIPTION
This pr:
- adds `#[local]` to `HB.instance`
- document which command supports which attribute. If you pass a non-supported attribute to a command you get an error.
- fixes #88