### PR TITLE
Smart elab context

### DIFF
--- a/hb.elpi
+++ b/hb.elpi
@@ -164,6 +164,30 @@ argument->asset (const-decl Id (some Bo) (arity Ty)) (asset-alias Id Bo) :- !,
   std.assert! (var Ty) "Factories aliases should not be given a type".
 argument->asset X _ :- coq.error "Unsupported asset:" X.
 
+% we elaborate the entire spine of parameters and body lambdas together
+pred elaborate-params-skeleton i:term, i:arity, o:term, o:arity.
+elaborate-params-skeleton B A B3 A1 :- std.do! [
+  std.assert-ok! (coq.elaborate-arity-skeleton A _ A1) "Arity illtyped",
+  elaborate-params-skeleton.aux A1 B B1 K,
+  coq.arity->term A1 TB,
+  std.assert-ok! (coq.elaborate-skeleton B1 TB B2) "Body parameters illtyped",
+  elaborate-params-skeleton.aux2 K B2 B3,
+].
+
+type bind-trm (term -> bound-term) -> bound-term.
+type bind-stop term -> bound-term.
+
+pred elaborate-params-skeleton.aux i:arity, i:term, o:term, o:bound-term.
+elaborate-params-skeleton.aux (parameter _ _ _ R) (fun N T F) (fun N T F1) (bind-trm K) :-
+  pi x\ elaborate-params-skeleton.aux (R x) (F x) (F1 x) (K x).
+elaborate-params-skeleton.aux (arity uvar) T {{ I }} (bind-stop T).
+elaborate-params-skeleton.aux _ _ _ _ :- coq.error "You cannot give a type ot this definition".
+
+pred elaborate-params-skeleton.aux2 i:bound-term, i:term, o:term.
+elaborate-params-skeleton.aux2 (bind-trm B) (fun N T F) (fun N T F1) :-
+  pi x\ elaborate-params-skeleton.aux2 (B x) (F x) (F1 x).
+elaborate-params-skeleton.aux2 (bind-stop B) _ B.
+
 pred builder->string i:builder, o:string.
 builder->string (builder _ _ _ B) S :- coq.term->string (global B) S.
 

--- a/hb.elpi
+++ b/hb.elpi
@@ -1877,31 +1877,39 @@ declare-old-constant (some C) :-
   std.forall {coq.locate-all Id} (declare-old-located Id).
 declare-old-constant _ :- true.
 
-pred context->factory i:context-decl, o:factoryname.
-context->factory (context-item IDT _ TTySkel none t\ context-item _ _ (TF t) none _\ context-end) GRF :- !,
-  coq.id->name IDT NameT,
-  std.assert-ok! (coq.elaborate-ty-skeleton TTySkel _ TTy) "context entry illtyped",
-  @pi-decl NameT TTy t\
-    std.assert! (factory? (TF t) (triple GRF _Params t))
-      "the last argument must be a factory applied to the type variable".
-context->factory (context-item ID _ TSkel none Factories) GRF :- !,
-  coq.id->name ID Name,
-  std.assert-ok! (coq.elaborate-ty-skeleton TSkel _ T) "context entry illtyped",
-  @pi-decl Name T x\ context->factory (Factories x) GRF.
-context->factory (context-item ID _ _ (some _) _) _ :-
+pred elaborate-context-skel->factory i:context-decl, o:context-decl, o:factoryname, o:diagnostic.
+elaborate-context-skel->factory
+  (context-item IDT IT TTySkel none t\ context-item IDF IF (TFSkel t) none _\ context-end)
+  (context-item IDT IT TTy none t\ context-item IDF IF (TFSkel t) none _\ context-end) GRF Diag
+:- !, std.do-ok! Diag [
+  coq.elaborate-ty-skeleton TTySkel _ TTy,
+  (d\ coq.id->name IDT NameT),
+  (d\ @pi-decl NameT TTy t\ purge-id (TFSkel t) (TFSkel1 t), coq.elaborate-ty-skeleton (TFSkel1 t) _ (TF1 t) d),
+  (d\ @pi-decl NameT TTy t\ std.assert! (factory? (TF1 t) (triple GRF _Params t)) "the last argument must be a factory applied to the type variable"),
+].
+elaborate-context-skel->factory (context-item ID I TSkel none C) (context-item ID I T none C1) GRF Diag :- !, std.do-ok! Diag [
+  coq.elaborate-ty-skeleton TSkel _ T,
+  (d\ coq.id->name ID Name),
+  (d\ @pi-decl Name T x\ elaborate-context-skel->factory (C x) (C1 x) GRF d),
+].
+elaborate-context-skel->factory (context-item ID _ _ (some _) _) _ _ _ :-
   coq.error "context item cannot be given a body:" ID.
+
+pred purge-id i:term, o:term.
+purge-id T T1 :-
+  (pi fresh t v\ copy {{lib:@hb.id lp:t lp:v}} fresh :- !) => copy T T1.
 
 pred main-begin-declare-builders i:context-decl.
 main-begin-declare-builders CtxSkel :- std.do! [
   Name is "Builders_" ^ {term_to_string {new_int}}, % TODO?
-  context->factory CtxSkel GRF,
+  std.assert-ok! (elaborate-context-skel->factory CtxSkel Ctx GRF) "Context illtyped",
   coq.env.begin-module Name none,
   if (GRF = indt FRecord) (std.do! [
     coq.env.begin-module "Super" none,
     std.forall {coq.CS.canonical-projections FRecord} declare-old-constant,
     coq.env.end-module _]) (true),
   coq.env.begin-section Name,
-  builders-postulate-factories CtxSkel,
+  builders-postulate-factories Ctx,
 ].
 
 pred postulate-factory-abbrev i:term, i:list term, i:id, i:factoryname, o:term.
@@ -1960,7 +1968,7 @@ builders-postulate-factories (context-item IDT _ TySkel none t\ context-item IDF
 
 builders-postulate-factories (context-item ID _ TSkel none Factories) :- std.do! [
   if-verbose (coq.say "HB: postulating" ID),
-  std.assert-ok! (coq.elaborate-ty-skeleton TSkel _ T) "builders-postulate-factorie: illtyped context",
+  std.assert-ok! (coq.elaborate-ty-skeleton TSkel _ T) "builders-postulate-factories: illtyped context",
   if (var T) (coq.fresh-type T) true,
   @local! => hb-add-const ID _ T @opaque! P, % no body, local -> a variable
   TheParam = global (const P),

--- a/structures.v
+++ b/structures.v
@@ -289,8 +289,9 @@ sigT->list-w-params {{ lib:@hb.sigT _ lp:{{ fun N Ty B }} }} L C :-
   @pi-decl N Ty t\
     product->triples (B t) (Rest t) C.
 
-main [const-decl Module (some B) _] :- !, std.do! [
-  sigT->list-w-params B GRFS ClosureCheck, !,
+main [const-decl Module (some B) A] :- !, std.do! [
+  elaborate-params-skeleton B A B1 _,
+  sigT->list-w-params B1 GRFS ClosureCheck, !,
   with-attributes (main-declare-structure Module GRFS ClosureCheck),
 ].
 main _ :- coq.error "Usage: HB.structure Definition <ModuleName> := { A of <Factory1> A & … & <FactoryN> A }".


### PR DESCRIPTION
```
HB.factory Record pred_subZmodule V (S : {pred V})
    (subS : zmodPred S)
    (kS : keyed_pred subS)
    (U : indexed Type) of subChoice V S U := {}.

HB.builders Context V S subS kS U of pred_subZmodule V S subS kS U.
```
this now works, but I guess we could do the same for factory and mixin

Fix #133 (piled on #135 to ease testing)