### PR TITLE
optimizations

### DIFF
--- a/structures.v
+++ b/structures.v
@@ -354,10 +354,9 @@ main [const-decl Name (some BodySkel) TyWPSkel] :- !, std.do! [
   factory-alias->gref FactoryAlias Factory,
   std.assert! (factory-nparams Factory NParams) "Not a factory synthesized by HB",
   hack-section-discharging SectionBody SectionBodyHack,
-  if (Name = "_")
-     (TheFactory = SectionBodyHack)
-     (hb-add-const Name SectionBodyHack _ @transparent! C,
-      TheFactory = (global (const C))),
+  if (Name = "_") (RealName is "HB_unnamed_factory_" ^ {std.any->string {new_int} }) (RealName = Name),
+  hb-add-const RealName SectionBodyHack _ @transparent! C,
+  TheFactory = (global (const C)),
   std.appendR {coq.mk-n-holes NParams} [TheType|_] Args,
   with-attributes (main-declare-instance TheType TheFactory Clauses),
 

--- a/structures.v
+++ b/structures.v
@@ -334,6 +334,13 @@ hack-section-discharging B B1 :- current-mode (builder-from TheFactory _), !,
   B1 = {{ let _ : lp:TheFactoryTy := lp:TheFactory in lp:B }}.
 hack-section-discharging B B.
 
+pred optimize-body i:term, o:term.
+optimize-body (app[global (const C)| Args]) Red :- phant-abbrev _ (const C) _, !,
+  coq.env.const C (some B) _,
+  hd-beta B Args HD Stack,
+  unwind HD Stack Red.
+optimize-body X X.
+
 main [const-decl Name (some BodySkel) TyWPSkel] :- !, std.do! [
   std.assert-ok! (coq.elaborate-arity-skeleton TyWPSkel _ TyWP) "Definition type illtyped",
   coq.arity->term TyWP Ty,
@@ -354,8 +361,9 @@ main [const-decl Name (some BodySkel) TyWPSkel] :- !, std.do! [
   factory-alias->gref FactoryAlias Factory,
   std.assert! (factory-nparams Factory NParams) "Not a factory synthesized by HB",
   hack-section-discharging SectionBody SectionBodyHack,
+  optimize-body SectionBodyHack OptimizedBody,
   if (Name = "_") (RealName is "HB_unnamed_factory_" ^ {std.any->string {new_int} }) (RealName = Name),
-  hb-add-const RealName SectionBodyHack _ @transparent! C,
+  hb-add-const RealName OptimizedBody _ @transparent! C,
   TheFactory = (global (const C)),
   std.appendR {coq.mk-n-holes NParams} [TheType|_] Args,
   with-attributes (main-declare-instance TheType TheFactory Clauses),


### PR DESCRIPTION
the first one brings down the last instance in ssralg to 0.4s, slow but tolerable.
the second one is just to avoid being silly and store `s.phant_Build crap` instead of `s.Build less crap`, it does not impact performances too much for not.

I believe the root problem is still there:
```
Set Printing All. Print prod_is_a_Ring.
(*
prod_is_a_Ring = 
@Ring.Pack (prod (Ring.sort R1) (Ring.sort R2))
  (@Ring.Class (prod (Ring.sort R1) (Ring.sort R2))
	 (HB_unnamed_factory_105 (Ring_to_Zmodule R1) (Ring_to_Zmodule R2))
     (prod_eqMixin
        (Choice_to_Equality (Zmodule_to_Choice (Ring_to_Zmodule R1)))
        (Choice_to_Equality (Zmodule_to_Choice (Ring_to_Zmodule R2))))
     (prod_choiceMixin (Zmodule_to_Choice (Ring_to_Zmodule R1))
        (Zmodule_to_Choice (Ring_to_Zmodule R2))) HB_unnamed_factory_107)
     : Ring.type
*)
```
This instance is where the "coercion chain problem" pops up and is still manageable, hence were we can debug it.
(FTR: before this PR this term was already gigantic and contained `phant_Build crap`)

CC @CohenCyril @pi8027 