### PR TITLE
Attribute "arg_sort"

### DIFF
--- a/.nix/config.nix
+++ b/.nix/config.nix
@@ -6,7 +6,7 @@
   select = "coq-8.13";
   inputs."coq-8.13".coqPackages = {
     coq.override.version = "8.13";
-    mathcomp.override.version = "gares:hierarchy-builder";
+    mathcomp.override.version = "hierarchy-builder";
     mathcomp-single.ci = true;
   };
 }

--- a/.nix/coq-overlays/mathcomp-single/default.nix
+++ b/.nix/coq-overlays/mathcomp-single/default.nix
@@ -1,6 +1,13 @@
 { mathcomp, coq-elpi, hierarchy-builder, version ? null }:
 (mathcomp.override {single = true;}).overrideAttrs (old: {
-  buildPhase = "make -j $(max_jobs) -C mathcomp ./algebra/ssralg.vo";
+  patchPhase = ''
+    sed -i '/STOP\./Q' mathcomp/ssreflect/order.v
+    echo "End Order." >> mathcomp/ssreflect/order.v
+  '';
+  buildPhase = ''
+    make -j$NIX_BUILD_CORES -C mathcomp only\
+      TGTS="fingroup/presentation.vo algebra/ssralg.vo ssreflect/order.vo"
+  '';
   propagatedBuildInputs = old.propagatedBuildInputs ++
                           [ coq-elpi hierarchy-builder ];
   installPhase = "echo NO INSTALL";

--- a/hb.elpi
+++ b/hb.elpi
@@ -92,7 +92,7 @@ with-attributes P :-
   attributes A,
 
 % HACK: move to coq-elpi proper, remove when coq-elpi > 1.9.2
-(pi S L AS Prefix R R1 Map PS\ 
+(pi S L AS Prefix R R1 Map PS\
   parse-attributes.aux [attribute S (node L)|AS] Prefix R :-
     if (Prefix = "") (PS = S) (PS is Prefix ^ "." ^ S), supported-attribute (att PS attmap), !,
     parse-attributes.aux AS Prefix R1,
@@ -106,6 +106,7 @@ with-attributes P :-
     att "mathcomp.axiom" string,
     att "infer" attmap,
     att "key" string,
+    att "arg_sort" bool,
   ] Opts, !,
   Opts => P.
 
@@ -142,6 +143,10 @@ coq.ground-record-decl? (field _ ID Ty D) :-
 pred if-verbose i:prop.
 if-verbose P :- get-option "verbose" tt, !, P.
 if-verbose _.
+
+pred if-arg-sort i:prop.
+if-arg-sort P :- get-option "arg_sort" tt, !, P.
+if-arg-sort _.
 
 pred if-MC-compat i:(option gref -> prop).
 if-MC-compat P :- get-option "mathcomp" tt, !, P none.
@@ -1596,14 +1601,13 @@ declare-class+structure MLwP (indt ClassInd) (indt StructureInd) SortProjection 
   coq.CS.canonical-projections StructureInd [some SortP, some ClassP],
   global (const SortP) = SortProjection,
   global (const ClassP) = ClassProjection,
+
 ].
 
 % Declares "sort" as a coercion Structurename >-> Sortclass
 pred declare-sort-coercion i:structure, i:term.
 declare-sort-coercion StructureName (global Proj) :-
-
   if-verbose (coq.say "HB: declare sort coercion"),
-
   @global! => hb-coercion-declare (coercion Proj 0 StructureName sortclass).
 
 pred if-class-already-exists-error i:id, i:list class, i:list mixinname.
@@ -1761,7 +1765,15 @@ main-declare-structure Module GRFSwP ClosureCheck :- std.do! [
 
   if-verbose (coq.say "HB: start module Exports"),
 
+  if-arg-sort (
+    if-verbose (coq.say "HB: define arg_sort"),
+    std.assert-ok! (coq.typecheck SortProjection SortProjTy)
+      "HB: BUG: cannot retype projection",
+    hb-add-const "arg_sort" SortProjection SortProjTy ff ArgSortCst
+  ),
+
   hb-begin-module "Exports",
+  if-arg-sort (declare-sort-coercion Structure (global (const ArgSortCst))),
   declare-sort-coercion Structure SortProjection,
 
   if-verbose (coq.say "HB: exporting unification hints"),

--- a/structures.v
+++ b/structures.v
@@ -269,6 +269,15 @@ Elpi Export HB.mixin.
   HB.structure Definition StructureName := { A of Factory1 A & … & FactoryN A & }.
   >>
 
+  Attributes:
+  - [#[mathcomp]] attempts to generate a backward compatibility layer with mathcomp:
+    trying to infer the right [Structure.pack],
+  - [#[infer("variable")]] provides a structure where [variable] has type [Type]
+    and will try to infer it's type by unification (with canonical strucutre inference),
+  - [#[arg_sort]] defines an alias [arg_sort] for [sort], and declares it as the
+    main coercion. [sort] is still declared as a coercion but the only reason is
+    to make sure Coq does not print it.
+    Cf https://github.com/math-comp/math-comp/blob/17dd3091e7f809c1385b0c0be43d1f8de4fa6be0/mathcomp/fingroup/fingroup.v#L225-L243.
 *)
 
 Elpi Command HB.structure.


### PR DESCRIPTION
- "arg_sort" adds an intermediate coercion class `arg_sort` as
  documented in the header of fingroup.v
cf https://github.com/math-comp/math-comp/tree/hierarchy-builder-fingroup/mathcomp
- test against hierarchy-builder math-comp branch