### PR TITLE
Shortening coercions in mixins.

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -14,6 +14,7 @@ jobs:
   hb:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         task: [ "coq-8.13", "coq-8.12", "coq-8.11" ]
     steps:
@@ -60,6 +61,7 @@ jobs:
   mathcomp:
     runs-on: ubuntu-latest
     needs: hb
+    if: always()
     strategy:
       fail-fast: false
       matrix:
@@ -87,6 +89,7 @@ jobs:
   mathcomp-planB-src:
     runs-on: ubuntu-latest
     needs: hb
+    if: always()
     strategy:
       matrix:
         task: [ "coq-8.13" ]
@@ -112,6 +115,7 @@ jobs:
 
   mathcomp-planB:
     runs-on: ubuntu-latest
+    if: always()
     strategy:
       matrix:
         task: [ "coq-8.13" ]

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 ## UNRELEASED
 
+- `#[compress_coercions]` attribute (off by default) to shorten coercions paths
+  in the synthesis of instances.
 - `HB.instance K F` deprecated in favor of `HB.instance Definition`
 - `#[log]` and `#[log(raw)]` to get printed Coq commands equivalent to what HB
   is doing. The raw print has higher changes to be reparsable.

--- a/HB/common/database.elpi
+++ b/HB/common/database.elpi
@@ -52,7 +52,8 @@ factory-alias->gref PhGR GR :- phant-abbrev GR PhGR _, !.
 factory-alias->gref GR GR :- phant-abbrev GR _ _, !.
 
 pred sub-class? i:class, i:class.
-sub-class? (class _ _ ML1P) (class _ _ ML2P) :-
+sub-class? (class C1 _ ML1P) (class C2 _ ML2P) :-
+  not (C1 = C2),
   list-w-params_list ML1P ML1,
   list-w-params_list ML2P ML2,
   std.forall ML2 (m2\ std.exists ML1 (m1\ m1 = m2)).

--- a/HB/common/database.elpi
+++ b/HB/common/database.elpi
@@ -23,6 +23,9 @@ mixin-src_src (mixin-src _ _ S) S.
 pred class_name i:class, o:classname.
 class_name (class N _ _) N.
 
+pred class_structure i:class, o:structure.
+class_structure (class _ S _) S.
+
 pred class-def_name i:prop, o:classname.
 class-def_name (class-def (class N _ _)) N.
 

--- a/HB/common/stdpp.elpi
+++ b/HB/common/stdpp.elpi
@@ -165,3 +165,24 @@ coq.copy-clauses-for-unfold [C|CS] [ClauseApp,Clause|L] :-
     copy (global (const C)) B1 :- !, copy B B1),
   coq.copy-clauses-for-unfold CS L.
 
+% like fold-map, needed for coq-elpi < 1.9
+
+pred coq.fold-map i:term, i:A, o:term, o:A.
+coq.fold-map X A Y A :- name X, !, X = Y, !. % avoid loading "coq.fold-map x A x A" at binders
+coq.fold-map (global _ as C) A C A :- !.
+coq.fold-map (sort _ as C) A C A :- !.
+coq.fold-map (fun N T F) A (fun N T1 F1) A2 :- !,
+  coq.fold-map T A T1 A1, pi x\ coq.fold-map (F x) A1 (F1 x) A2.
+coq.fold-map (let N T B F) A (let N T1 B1 F1) A3 :- !,
+  coq.fold-map T A T1 A1, coq.fold-map B A1 B1 A2, pi x\ coq.fold-map (F x) A2 (F1 x) A3.
+coq.fold-map (prod N T F) A (prod N T1 F1) A2 :- !,
+  coq.fold-map T A T1 A1, (pi x\ coq.fold-map (F x) A1 (F1 x) A2).
+coq.fold-map (app L) A (app L1) A1 :- !, std.fold-map L A coq.fold-map L1 A1.
+coq.fold-map (fix N Rno Ty F) A (fix N Rno Ty1 F1) A2 :- !,
+  coq.fold-map Ty A Ty1 A1, pi x\ coq.fold-map (F x) A1 (F1 x) A2.
+coq.fold-map (match T Rty B) A (match T1 Rty1 B1) A3 :- !,
+  coq.fold-map T A T1 A1, coq.fold-map Rty A1 Rty1 A2, std.fold-map B A2 coq.fold-map B1 A3.
+coq.fold-map (primitive _ as C) A C A :- !.
+coq.fold-map (uvar M L as X) A W A1 :- var X, !, std.fold-map L A coq.fold-map L1 A1, coq.mk-app-uvar M L1 W.
+% when used in CHR rules
+coq.fold-map (uvar X L) A (uvar X L1) A1 :- std.fold-map L A coq.fold-map L1 A1.

--- a/HB/common/synthesis.elpi
+++ b/HB/common/synthesis.elpi
@@ -108,7 +108,8 @@ namespace private {
 % [mixin-for T M MI] synthesizes an instance of mixin M on type T using
 % the databases [mixin-src] and [from]
 pred mixin-for i:term, i:mixinname, o:term.
-mixin-for T M MI :- mixin-src T M Tm, !, std.do! [
+mixin-for T M MICompressed :- mixin-src T M Tm, !, std.do! [
+  if-verbose (coq.say "HB: Trying to infer mixin for" M),
   std.assert-ok! (coq.typecheck Tm Ty) "mixin-for: Tm illtyped",
 
   factory? Ty (triple Factory Params _),
@@ -116,8 +117,17 @@ mixin-for T M MI :- mixin-src T M Tm, !, std.do! [
   if (M = Factory) (MI = Tm) (
       private.builder->term Params T Factory M B,
       coq.subst-fun [Tm] B MI
-  )
+  ),
+
+  if-verbose (coq.say "HB: Trying to compress mixin for" {coq.term->string MI}),
+  compress-coercion-paths MI MICompressed,
 ].
+
+pred compress-coercion-paths i:term, o:term.
+compress-coercion-paths MI MICompressed :-
+  if (get-option "compress_coercions" tt)
+     (compress MI MICompressed)
+     (MI = MICompressed).
 
 pred mixin-for_mixin-builder i:prop, o:term.
 mixin-for_mixin-builder (mixin-for _ _ B) B.

--- a/HB/common/utils.elpi
+++ b/HB/common/utils.elpi
@@ -15,7 +15,7 @@ with-attributes P :-
   attributes A,
 
 % HACK: move to coq-elpi proper, remove when coq-elpi > 1.9.2
-(pi S L AS Prefix R R1 Map PS\ 
+(pi S L AS Prefix R R1 Map PS\
   parse-attributes.aux [attribute S (node L)|AS] Prefix R :-
     if (Prefix = "") (PS = S) (PS is Prefix ^ "." ^ S), supported-attribute (att PS attmap), !,
     parse-attributes.aux AS Prefix R1,
@@ -32,6 +32,7 @@ with-attributes P :-
     att "arg_sort" bool,
     att "log" bool,
     att "log.raw" bool,
+    att "compress_coercions" bool,
   ] Opts, !,
   Opts => P.
 

--- a/HB/instance.elpi
+++ b/HB/instance.elpi
@@ -74,7 +74,7 @@ declare-all T [class Class Struct MLwP|Rest] [CS|L] :-
 
   if (not(local-cs? T Struct))
      true % we build it
-     (if-verbose (coq.say "HB: skipping alreay existing"
+     (if-verbose (coq.say "HB: skipping already existing"
                     {nice-gref->string Struct} "instance on"
                     {coq.term->string T}),
       fail),
@@ -86,8 +86,10 @@ declare-all T [class Class Struct MLwP|Rest] [CS|L] :-
 
   !,
   coq.term->gref T TGR,
+  coq.gref->path TGR TPath,
+  std.rev TPath [TMod|_],
   coq.gref->id TGR TID,
-  Name is TID ^ "_is_a_" ^ {gref->modname Struct},
+  Name is TMod ^ "_" ^ TID ^ "_canonical_" ^ {gref->modname Struct},
 
   if-verbose (coq.say "HB: declare canonical structure instance" Name),
 

--- a/HB/structure.elpi
+++ b/HB/structure.elpi
@@ -337,7 +337,7 @@ mk-compression-clauses StructureF StructureT [StructureE|Rest] Res :- std.do! [
   coq.mk-app (global C3) {coq.mk-n-holes Nparams3} H,
   RuleSkel = {{ fun x => lp:G (lp:F x) = lp:H x}},
   std.assert-ok! (coq.elaborate-skeleton RuleSkel _ Rule) "coercion composition fails",
-  (((pi X L\ fold-map X L X [X|L] :- var X, not(std.exists L (same_var X))) => fold-map Rule [] Rule Holes,
+  (((pi X L\ coq.fold-map X L X [X|L] :- var X, not(std.exists L (same_var X))) => coq.fold-map Rule [] Rule Holes,
   mk-compression-clause Holes Rule Clause,
   mk-compression-clauses StructureF StructureT Rest Clauses,
   Res = [Clause|Clauses]) ; (Res = [])),
@@ -345,7 +345,6 @@ mk-compression-clauses StructureF StructureT [StructureE|Rest] Res :- std.do! [
 
 pred mk-compression-clause i:list term, i:term, o:prop.
 mk-compression-clause [] (fun _ _ x\ app[_,_,LHS x,RHS x]) (pi x\ C x) :-
-  %pi x\ copy (LHS x) (L x), copy (RHS x) (R x), C x = (pi tmp\ compress (L x) (R tmp) :- !, compress x tmp, !).
   pi x\ copy (LHS x) (L x), copy (RHS x) (R x), C x = (pi tmp\ compress (L x) (R x)).
 mk-compression-clause [UV|Rest] T (pi v\ R v) :-
   pi v\ (pi U\ copy U v :- same_var U UV, !) => mk-compression-clause Rest T (R v).

--- a/HB/structure.elpi
+++ b/HB/structure.elpi
@@ -313,7 +313,42 @@ declare-coercion SortProjection ClassProjection
   log.coq.env.add-const-noimplicits SName SCoeBody STy @transparent! SC,
   log.coq.coercion.declare (coercion (const SC) 0 StructureF (grefclass StructureT)),
   log.coq.CS.declare-instance (const SC), % TODO: API in Elpi, take a @constant instead of gref
+
+  if-verbose (coq.say "HB: declare coercion path compression rules"),
+
+  findall-classes All,
+  CurrentTgtClass = (class TC StructureT TMLwP),
+  std.filter All (sub-class? CurrentTgtClass) AllTgtSuper,
+  std.map AllTgtSuper class_structure AllTgtSuperStructures,
+
+  mk-compression-clauses StructureF StructureT AllTgtSuperStructures AllCompressionClauses,
+  std.forall AllCompressionClauses (c\ log.coq.env.accumulate current "hb.db" (clause _ (before "compress:begin") c)),
 ].
+
+
+pred mk-compression-clauses i:gref, i:gref, i:list gref, o:list prop.
+mk-compression-clauses _ _ [] [].
+mk-compression-clauses StructureF StructureT [StructureE|Rest] Res :- std.do! [
+  std.assert! (coq.coercion.db-for (grefclass StructureF) (grefclass StructureT) [pr C1 Nparams1]) "wrong number of coercions",
+  std.assert! (coq.coercion.db-for (grefclass StructureT) (grefclass StructureE) [pr C2 Nparams2]) "wrong number of coercions",
+  std.assert! (coq.coercion.db-for (grefclass StructureF) (grefclass StructureE) [pr C3 Nparams3]) "wrong number of coercions",
+  coq.mk-app (global C1) {coq.mk-n-holes Nparams1} F,
+  coq.mk-app (global C2) {coq.mk-n-holes Nparams2} G,
+  coq.mk-app (global C3) {coq.mk-n-holes Nparams3} H,
+  RuleSkel = {{ fun x => lp:G (lp:F x) = lp:H x}},
+  std.assert-ok! (coq.elaborate-skeleton RuleSkel _ Rule) "coercion composition fails",
+  (((pi X L\ fold-map X L X [X|L] :- var X, not(std.exists L (same_var X))) => fold-map Rule [] Rule Holes,
+  mk-compression-clause Holes Rule Clause,
+  mk-compression-clauses StructureF StructureT Rest Clauses,
+  Res = [Clause|Clauses]) ; (Res = [])),
+].
+
+pred mk-compression-clause i:list term, i:term, o:prop.
+mk-compression-clause [] (fun _ _ x\ app[_,_,LHS x,RHS x]) (pi x\ C x) :-
+  %pi x\ copy (LHS x) (L x), copy (RHS x) (R x), C x = (pi tmp\ compress (L x) (R tmp) :- !, compress x tmp, !).
+  pi x\ copy (LHS x) (L x), copy (RHS x) (R x), C x = (pi tmp\ compress (L x) (R x)).
+mk-compression-clause [UV|Rest] T (pi v\ R v) :-
+  pi v\ (pi U\ copy U v :- same_var U UV, !) => mk-compression-clause Rest T (R v).
 
 pred join-body i:int, i:int, i:structure, i:term, i:term, i:term, i:term, i:term,
   i:list term, i:name, i:term, i:(term -> A), o:term.

--- a/Makefile.test-suite.coq.local
+++ b/Makefile.test-suite.coq.local
@@ -1,0 +1,9 @@
+COQ_MINOR=$(shell echo $(COQ_VERSION) | cut -d . -f 2 | cut -d + -f 1)
+
+post-all::
+	rm -f tests/compress_coe.v.hb
+	@$(COQC) $(COQFLAGS) $(COQLIBS) tests/compress_coe.v > tests/compress_coe.v.out.aux
+	case $(COQ_MINOR) in \
+	11|12) echo "No coercion compression on Coq 8.$(COQ_MINOR), skipping diff" ;;\
+	*)	diff -u tests/compress_coe.v.out tests/compress_coe.v.out.aux ;;\
+	esac

--- a/_CoqProject.test-suite
+++ b/_CoqProject.test-suite
@@ -53,6 +53,8 @@ tests/subtype.v
 tests/infer.v
 tests/exports.v
 tests/log_impargs_record.v
+tests/compress_coe.v
+
 
 -R tests HB.tests
 -R examples HB.examples

--- a/structures.v
+++ b/structures.v
@@ -175,6 +175,14 @@ pred current-mode o:declaration.
 
 pred module-to-export o:id, o:modpath.
 
+% coercions chains compression rules (we only care about non applicative
+% terms, since this is what you get when you apply coercions)
+:index (4)
+pred compress o:term, o:term.
+:name "compress:begin"
+compress (app L) (app L1) :- !, std.map L compress L1.
+compress X X.
+
 }}.
 
 (* %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% *)

--- a/tests/compress_coe.v
+++ b/tests/compress_coe.v
@@ -1,0 +1,37 @@
+From Coq Require Import ssreflect ssrfun.
+From HB Require Import structures.
+
+(**************************************************************************)
+(* Stage 2: AddComoid -> AddAG -> Ring                                  *)
+(**************************************************************************)
+
+HB.mixin Record hasA T := { a : T }.
+HB.structure Definition A := {T of hasA T}.
+
+HB.mixin Record hasB (p : unit) T of A T := { b : T }.
+HB.structure Definition B p := {T of A T & hasB p T}.
+
+HB.mixin Record hasC (p q : unit) T of B p T := { c : T }.
+HB.structure Definition C p q := {T of B p T & hasC p q T}.
+
+HB.mixin Record hasD T of C tt tt T := { d : T }.
+HB.structure Definition D := {T of C tt tt T & hasD T}.
+
+#[compress_coercions]
+HB.instance Definition prodA (A A' : A.type) :=
+  hasA.Build (A * A')%type (a, a).
+
+#[compress_coercions]
+HB.instance Definition prodB p (B B' : B.type p) :=
+  hasB.Build p (B * B')%type (b, b).
+
+#[compress_coercions]
+HB.instance Definition prodC p q (C C' : C.type p q) :=
+  hasC.Build p q (C * C')%type (c, c).
+
+#[compress_coercions]
+HB.instance Definition prodD (D D' : D.type) :=
+  hasD.Build (D * D')%type (d, d).
+
+Set Printing Coercions.
+Print prod_prod_canonical_D.

--- a/tests/compress_coe.v.out
+++ b/tests/compress_coe.v.out
@@ -1,0 +1,13 @@
+prod_prod_canonical_D = 
+fun D D' : D.type =>
+{|
+  D.sort := D.sort D * D.sort D';
+  D.class :=
+    {|
+      D.hasA_mixin := prodA (D_to_A D) (D_to_A D');
+      D.hasB_mixin := prodB tt (D_to_B D) (D_to_B D');
+      D.hasC_mixin := prodC tt tt (D_to_C D) (D_to_C D');
+      D.hasD_mixin := prodD D D'
+    |}
+|}
+     : D.type -> D.type -> D.type


### PR DESCRIPTION
Hi @gares here is a fix for having shorter coercion paths in https://github.com/math-comp/hierarchy-builder/issues/150.
Unfortunately in the current state, it makes everything even slower, probably because I did not find the right API functions to get as specific coercion, or because it is not bound yet... you tell me

Fix #150 