### PR TITLE
cleanup the name collision mess

### DIFF
--- a/HB/builders.elpi
+++ b/HB/builders.elpi
@@ -42,11 +42,16 @@ builders.end :- std.do! [
      (coq.error "No builders to declare, did you forget HB.instance?")
      true,
 
+  std.findall (abbrev-to-export F_ N_ A_) ExportClauses,
+  coq.env.current-path CurModPath,
+  std.filter ExportClauses (export.private.abbrev-in-module CurModPath) ExportClausesFiltered,
+
   % TODO: Do we need this module?
   gref->modname GR 1 "" M,
   Name is M ^ "_Exports",
   log.coq.env.begin-module Name,
   std.forall Clauses (c\ log.coq.env.accumulate current "hb.db" (clause _ _ c)),
+  std.forall ExportClausesFiltered (c\ log.coq.env.accumulate current "hb.db" (clause _ _ c)),
 
   log.coq.env.end-module-name Name Exports,
   log.coq.env.end-module-name ModName _,

--- a/HB/builders.elpi
+++ b/HB/builders.elpi
@@ -43,7 +43,7 @@ builders.end :- std.do! [
      true,
 
   % TODO: Do we need this module?
-  gref->modname GR M,
+  gref->modname GR 1 "" M,
   Name is M ^ "_Exports",
   log.coq.env.begin-module Name,
   std.forall Clauses (c\ log.coq.env.accumulate current "hb.db" (clause _ _ c)),

--- a/HB/common/database.elpi
+++ b/HB/common/database.elpi
@@ -47,6 +47,11 @@ instance-to-export_instance (instance-to-export _ _ M) M.
 pred instance-to-export_instance-nice i:prop, o:id.
 instance-to-export_instance-nice (instance-to-export _ M _) M.
 
+pred abbrev-to-export_name i:prop, o:id.
+abbrev-to-export_name (abbrev-to-export _ N _) N.
+pred abbrev-to-export_body i:prop, o:term.
+abbrev-to-export_body (abbrev-to-export _ _ B) (global B).
+
 pred extract-builder i:prop, o:builder.
 extract-builder (builder-decl B) B.
 

--- a/HB/common/log.elpi
+++ b/HB/common/log.elpi
@@ -24,7 +24,8 @@ env.add-const-noimplicits Name Bo Ty Opaque C :- std.do! [
     (coq.error "HB: cannot infer some information in" Name
                ":" {coq.term->string Ty} ":=" {coq.term->string Bo})
     true,
-  coq.env.add-const Name Bo Ty Opaque C,
+  avoid-name-collision Name Name1,
+  coq.env.add-const Name1 Bo Ty Opaque C,
   if (var Ty) (Ty? = none) (Ty? = some Ty),
   log.private.log-vernac (log.private.coq.vernac.definition Name Ty? Bo),
   @local! => arguments.set-implicit (const C) [[]],

--- a/HB/common/log.elpi
+++ b/HB/common/log.elpi
@@ -27,6 +27,19 @@ env.add-const-noimplicits Name Bo Ty Opaque C :- std.do! [
   avoid-name-collision Name Name1,
   coq.env.add-const Name1 Bo Ty Opaque C,
   if (var Ty) (Ty? = none) (Ty? = some Ty),
+  log.private.log-vernac (log.private.coq.vernac.definition Name1 Ty? Bo),
+  @local! => arguments.set-implicit (const C) [[]],
+].
+
+pred env.add-const-noimplicits-failondup i:id, i:term, i:term, i:opaque?, o:constant.
+env.add-const-noimplicits-failondup Name Bo Ty Opaque C :- std.do! [
+  % TODO: refine when we switch to add-section-variable/add-const
+  if (not(ground_term Ty ; ground_term Bo))
+    (coq.error "HB: cannot infer some information in" Name
+               ":" {coq.term->string Ty} ":=" {coq.term->string Bo})
+    true,
+  coq.env.add-const Name Bo Ty Opaque C,
+  if (var Ty) (Ty? = none) (Ty? = some Ty),
   log.private.log-vernac (log.private.coq.vernac.definition Name Ty? Bo),
   @local! => arguments.set-implicit (const C) [[]],
 ].

--- a/HB/common/stdpp.elpi
+++ b/HB/common/stdpp.elpi
@@ -25,6 +25,12 @@ list-diff L [D|DS] R :-
   std.filter L (x\ not(x = D)) L1,
   list-diff L1 DS R.
 
+pred list-uniq i:list A, o:list A.
+pred list-uniq.seen i:A.
+list-uniq [] [].
+list-uniq [X|XS] YS :- list-uniq.seen X, !, list-uniq XS YS.
+list-uniq [X|XS] [X|YS] :- list-uniq.seen X => list-uniq XS YS.
+
 pred list-eq-set i:list A, i:list A.
 list-eq-set L1 L2 :- list-diff L1 L2 [], list-diff L2 L1 [].
 

--- a/HB/common/utils.elpi
+++ b/HB/common/utils.elpi
@@ -97,6 +97,12 @@ nice-gref->string X Mod :-
 nice-gref->string X S :-
   coq.term->string (global X) S.
 
+pred compat.concat i:string, i:list string, o:string.
+compat.concat S L O :- coq.version _ _ N _, N > 12, !, std.string.concat S L O.
+compat.concat S L O :- compat.concat.aux L S O.
+compat.concat.aux [] _ "".
+compat.concat.aux [X] _ X :- !.
+compat.concat.aux [X|XS] Sep O :- compat.concat.aux XS Sep O1, O is X ^ Sep ^ O1.
 
 pred gref->modname i:gref, i:int, i:string, o:string.
 gref->modname GR NComp Sep ModName :-
@@ -106,7 +112,7 @@ gref->modname GR NComp Sep ModName :-
   if (Len > NComp) true (coq.error "Not enough enclosing modules for" {coq.gref->string GR}),
   std.drop 1 PathRev Mods, % drop the label
   std.take NComp Mods L,
-  std.string.concat Sep {std.rev L} ModName.
+  compat.concat Sep {std.rev L} ModName.
 pred gref->modname-label i:gref, i:int, i:string, o:string.
 gref->modname-label GR NComp Sep ModName :-
   coq.gref->path GR Path,
@@ -114,7 +120,7 @@ gref->modname-label GR NComp Sep ModName :-
   std.length PathRev Len,
   if (Len >= NComp) (N = NComp) (N = Len),
   std.take N PathRev L,
-  std.string.concat Sep {std.rev [ID|L]} ModName.
+  compat.concat Sep {std.rev [ID|L]} ModName.
 
 pred avoid-name-collision i:string, o:string.
 avoid-name-collision S S1 :-

--- a/HB/common/utils.elpi
+++ b/HB/common/utils.elpi
@@ -92,14 +92,36 @@ builder->string (builder _ _ _ B) S :- coq.term->string (global B) S.
 pred nice-gref->string i:gref, o:string.
 nice-gref->string X Mod :-
   coq.gref->path X Path,
-  std.rev Path [_,Mod|_], !.
+  std.rev Path [_,Mod1,Mod2|_], !,
+  Mod is Mod2 ^ "_" ^ Mod1.
 nice-gref->string X S :-
   coq.term->string (global X) S.
 
-pred gref->modname i:gref, o:id.
-gref->modname GR ModName :-
+
+pred gref->modname i:gref, i:int, i:string, o:string.
+gref->modname GR NComp Sep ModName :-
   coq.gref->path GR Path,
-  if (std.rev Path [_,ModName|_]) true (coq.error "No enclosing module for " GR).
+  std.rev Path PathRev,
+  std.length Path Len,
+  if (Len > NComp) true (coq.error "Not enough enclosing modules for" {coq.gref->string GR}),
+  std.drop 1 PathRev Mods, % drop the label
+  std.take NComp Mods L,
+  std.string.concat Sep {std.rev L} ModName.
+pred gref->modname-label i:gref, i:int, i:string, o:string.
+gref->modname-label GR NComp Sep ModName :-
+  coq.gref->path GR Path,
+  std.rev Path [ID|PathRev],
+  std.length PathRev Len,
+  if (Len >= NComp) (N = NComp) (N = Len),
+  std.take N PathRev L,
+  std.string.concat Sep {std.rev [ID|L]} ModName.
+
+pred avoid-name-collision i:string, o:string.
+avoid-name-collision S S1 :-
+  coq.locate-all S L,
+  if (std.mem L (loc-gref _) ; std.mem L (loc-abbreviation _))
+     (S1 is S ^ "__" ^ {std.any->string {new_int}})
+     (S1 is S).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % function to predicate generic constructions %

--- a/HB/common/utils.elpi
+++ b/HB/common/utils.elpi
@@ -119,7 +119,7 @@ gref->modname-label GR NComp Sep ModName :-
 pred avoid-name-collision i:string, o:string.
 avoid-name-collision S S1 :-
   coq.locate-all S L,
-  if (std.mem L (loc-gref _) ; std.mem L (loc-abbreviation _))
+  if (std.mem L (loc-gref GR), coq.gref->path GR P, coq.env.current-path P)
      (S1 is S ^ "__" ^ {std.any->string {new_int}})
      (S1 is S).
 

--- a/HB/context.elpi
+++ b/HB/context.elpi
@@ -29,7 +29,7 @@ namespace private {
 % to the corresponding mixin using mixin-for
 pred postulate-mixin i:w-args mixinname, i:list prop, o:list prop.
 postulate-mixin (triple M Ps T) MSL [mixin-src T M (global (const C))|MSL] :- MSL => std.do! [
-  Name is "mixin_" ^ {gref->modname M},
+  Name is "mixin_" ^ {gref->modname M 2 "_"},
 
   if-verbose (coq.say "HB: postulate" Name "on" {coq.term->string T}),
 

--- a/HB/export.elpi
+++ b/HB/export.elpi
@@ -1,16 +1,29 @@
 /*        Hierarchy Builder: algebraic hierarchies made easy
     This software is released under the terms of the MIT license              */
 
+pred export.any i:id.
+export.any S :-
+  coq.locate-all S L,
+  if (L = []) (coq.error "HB: cannot locate" S) true,
+  if (L = [X]) (export.any.aux S X) (coq.error "HB:" S "is ambiguous:" L).
+export.any.aux S (loc-gref GR) :- export.abbrev S GR.
+export.any.aux S (loc-modpath MP) :- export.module S MP.
+export.any.aux S X :- coq.error "HB:" S "denotes" X "which is not supported for exporting".
 
-% [export.module MFilter] exports a MFilter now adds it to the collection of
+% [export.module Module] exports a Module now adds it to the collection of
 % modules to export in the end of the current enclosing module,
 % by the command HB.Exports
 % CAVEAT: "module" is a keyword, we put it in the namespace by hand
 pred export.module i:id, i:modpath.
-export.module NiceModule MFilter :- !,
-  log.coq.env.export-module NiceModule MFilter,
+export.module NiceModule Module :- !,
+  log.coq.env.export-module NiceModule Module,
   coq.env.current-library File,
-  log.coq.env.accumulate current "hb.db" (clause _ _ (module-to-export File NiceModule MFilter)).
+  log.coq.env.accumulate current "hb.db" (clause _ _ (module-to-export File NiceModule Module)).
+
+pred export.abbrev i:id, i:gref.
+export.abbrev NiceName GR :- !,
+  coq.env.current-library File,
+  log.coq.env.accumulate current "hb.db" (clause _ _ (abbrev-to-export File NiceName GR)).
 
 pred export.reexport-all-modules-and-CS i:option string.
 export.reexport-all-modules-and-CS Filter :- std.do! [
@@ -29,15 +42,28 @@ export.reexport-all-modules-and-CS Filter :- std.do! [
 
   std.findall (instance-to-export File NiceInstance_ Const_) InstCL,
   std.filter InstCL (private.instance-in-module MFilter) InstCLFiltered,
-  %std.map InstCL instance-to-export_instance-nice NiceInsts,
   std.map InstCLFiltered instance-to-export_instance Insts,
 
   if-verbose (coq.say "HB: exporting CS instances" Insts),
   std.forall Insts log.coq.CS.declare-instance,
+
+  std.findall (abbrev-to-export File NiceAbbrev_ GR_) InstAbbL,
+  std.filter InstAbbL (private.abbrev-in-module MFilter) InstAbbLFiltered,
+  std.map InstAbbLFiltered abbrev-to-export_name AbbNames,
+  std.map InstAbbLFiltered abbrev-to-export_body AbbBodies,
+
+  if-verbose (coq.say "HB: exporting Abbreviations" AbbNames),
+  std.forall2 AbbNames AbbBodies (n\b\@global! => log.coq.notation.add-abbreviation n 0 b ff _),
+
 ].
 
 
 namespace private {
+
+pred abbrev-in-module i:list string, i:prop.
+abbrev-in-module PM (abbrev-to-export _ _ GR) :-
+  coq.gref->path GR PC,
+  std.appendR PM _ PC. % sublist
 
 pred module-in-module i:list string, i:prop.
 module-in-module PM (module-to-export _ _ M) :-

--- a/HB/export.elpi
+++ b/HB/export.elpi
@@ -31,8 +31,10 @@ export.reexport-all-modules-and-CS Filter :- std.do! [
   export.private.compute-filter Filter MFilter,
   if-verbose (coq.say "HB: exporting under the module path" MFilter),
 
+  % NODE: std.list-uniq is for coq < 8.13
+
   std.findall (module-to-export File NiceModule_ Module_) ModsCL,
-  std.filter ModsCL (export.private.module-in-module MFilter) ModsCLFiltered,
+  std.filter {std.list-uniq ModsCL} (export.private.module-in-module MFilter) ModsCLFiltered,
   std.map ModsCLFiltered module-to-export_module-nice NiceMods,
   std.map ModsCLFiltered module-to-export_module Mods,
 
@@ -41,14 +43,14 @@ export.reexport-all-modules-and-CS Filter :- std.do! [
 
 
   std.findall (instance-to-export File NiceInstance_ Const_) InstCL,
-  std.filter InstCL (export.private.instance-in-module MFilter) InstCLFiltered,
+  std.filter {std.list-uniq InstCL} (export.private.instance-in-module MFilter) InstCLFiltered,
   std.map InstCLFiltered instance-to-export_instance Insts,
 
   if-verbose (coq.say "HB: exporting CS instances" Insts),
   std.forall Insts log.coq.CS.declare-instance,
 
   std.findall (abbrev-to-export File NiceAbbrev_ GR_) InstAbbL,
-  std.filter InstAbbL (export.private.abbrev-in-module MFilter) InstAbbLFiltered,
+  std.filter {std.list-uniq InstAbbL} (export.private.abbrev-in-module MFilter) InstAbbLFiltered,
   std.map InstAbbLFiltered abbrev-to-export_name AbbNames,
   std.map InstAbbLFiltered abbrev-to-export_body AbbBodies,
 

--- a/HB/export.elpi
+++ b/HB/export.elpi
@@ -28,11 +28,11 @@ export.abbrev NiceName GR :- !,
 pred export.reexport-all-modules-and-CS i:option string.
 export.reexport-all-modules-and-CS Filter :- std.do! [
   coq.env.current-library File,
-  private.compute-filter Filter MFilter,
+  export.private.compute-filter Filter MFilter,
   if-verbose (coq.say "HB: exporting under the module path" MFilter),
 
   std.findall (module-to-export File NiceModule_ Module_) ModsCL,
-  std.filter ModsCL (private.module-in-module MFilter) ModsCLFiltered,
+  std.filter ModsCL (export.private.module-in-module MFilter) ModsCLFiltered,
   std.map ModsCLFiltered module-to-export_module-nice NiceMods,
   std.map ModsCLFiltered module-to-export_module Mods,
 
@@ -41,14 +41,14 @@ export.reexport-all-modules-and-CS Filter :- std.do! [
 
 
   std.findall (instance-to-export File NiceInstance_ Const_) InstCL,
-  std.filter InstCL (private.instance-in-module MFilter) InstCLFiltered,
+  std.filter InstCL (export.private.instance-in-module MFilter) InstCLFiltered,
   std.map InstCLFiltered instance-to-export_instance Insts,
 
   if-verbose (coq.say "HB: exporting CS instances" Insts),
   std.forall Insts log.coq.CS.declare-instance,
 
   std.findall (abbrev-to-export File NiceAbbrev_ GR_) InstAbbL,
-  std.filter InstAbbL (private.abbrev-in-module MFilter) InstAbbLFiltered,
+  std.filter InstAbbL (export.private.abbrev-in-module MFilter) InstAbbLFiltered,
   std.map InstAbbLFiltered abbrev-to-export_name AbbNames,
   std.map InstAbbLFiltered abbrev-to-export_body AbbBodies,
 
@@ -58,7 +58,7 @@ export.reexport-all-modules-and-CS Filter :- std.do! [
 ].
 
 
-namespace private {
+namespace export.private {
 
 pred abbrev-in-module i:list string, i:prop.
 abbrev-in-module PM (abbrev-to-export _ _ GR) :-

--- a/HB/graph.elpi
+++ b/HB/graph.elpi
@@ -18,6 +18,13 @@ to-file File :- !, std.do! [
 
 namespace private {
 
+pred compat.concat i:string, i:list string, o:string.
+compat.concat S L O :- coq.version _ _ N _, N > 12, !, std.string.concat S L O.
+compat.concat S L O :- compat.concat.aux L S O.
+compat.concat.aux [] _ "".
+compat.concat.aux [X] _ X :- !.
+compat.concat.aux [X|XS] Sep O :- compat.concat.aux XS Sep O1, O is X ^ Sep ^ O1.
+
 pred gref->modname i:gref, i:int, i:string, o:string.
 gref->modname GR NComp Sep ModName :-
   coq.gref->path GR Path,
@@ -26,7 +33,7 @@ gref->modname GR NComp Sep ModName :-
   if (Len > NComp) true (coq.error "Not enough enclosing modules for" {coq.gref->string GR}),
   std.drop 1 PathRev Mods, % drop the label
   std.take NComp Mods L,
-  std.string.concat Sep {std.rev L} ModName.
+  compat.concat Sep {std.rev L} ModName.
 
 pred pp-coercion-dot i:out_stream, i:coercion. 
 pp-coercion-dot OC (coercion _ _ Src (grefclass Tgt)) :- class-def (class Src _ _), class-def (class Tgt _ _), !, std.do! [

--- a/HB/graph.elpi
+++ b/HB/graph.elpi
@@ -1,4 +1,3 @@
-
 /*        Hierarchy Builder: algebraic hierarchies made easy
     This software is released under the terms of the MIT license              */
 
@@ -19,18 +18,21 @@ to-file File :- !, std.do! [
 
 namespace private {
 
-pred nice-gref->string i:gref, o:string.
-nice-gref->string X Mod :-
-  coq.gref->path X Path,
-  std.rev Path [_,Mod|_], !.
-nice-gref->string X S :-
-  coq.term->string (global X) S.
+pred gref->modname i:gref, i:int, i:string, o:string.
+gref->modname GR NComp Sep ModName :-
+  coq.gref->path GR Path,
+  std.rev Path PathRev,
+  std.length Path Len,
+  if (Len > NComp) true (coq.error "Not enough enclosing modules for" {coq.gref->string GR}),
+  std.drop 1 PathRev Mods, % drop the label
+  std.take NComp Mods L,
+  std.string.concat Sep {std.rev L} ModName.
 
 pred pp-coercion-dot i:out_stream, i:coercion. 
 pp-coercion-dot OC (coercion _ _ Src (grefclass Tgt)) :- class-def (class Src _ _), class-def (class Tgt _ _), !, std.do! [
-  output OC {nice-gref->string Tgt},
+  output OC {gref->modname Tgt 2 "_"},
   output OC " -> ",
-  output OC {nice-gref->string Src},
+  output OC {gref->modname Src 2 "_"},
   output OC ";\n",
 ].
 pp-coercion-dot _ _.

--- a/HB/instance.elpi
+++ b/HB/instance.elpi
@@ -86,12 +86,7 @@ declare-all T [class Class Struct MLwP|Rest] [pr Name CS|L] :-
 
   !,
   coq.term->gref T TGR,
-  coq.gref->path TGR TPath,
-  std.rev TPath [TMod|_],
-  coq.gref->id TGR TID,
-  if (TMod = TID)
-     (Name is TID ^ "_canonical_" ^ {gref->modname Struct} ^ "_" ^ {std.any->string {new_int}})
-     (Name is TMod ^ "_" ^ TID ^ "_canonical_" ^ {gref->modname Struct} ^ "_" ^ {std.any->string {new_int}}),
+  Name is  {gref->modname-label TGR 1 "_"} ^ "__canonical__" ^ {gref->modname Struct 2 "_"},
 
   if-verbose (coq.say "HB: declare canonical structure instance" Name),
 
@@ -148,7 +143,7 @@ add-mixin T FGR MakeCanon MissingMixin [MixinSrcCl, BuilderDeclCl] :-
   % If the mixin instance is already a constant there is no need to
   % alias it.
   if (Bo = global (const C)) true
-    (Name is {nice-gref->string FGR} ^"_to_" ^ {nice-gref->string MixinName} ^ "__" ^ {std.any->string {new_int}},
+    (Name is {gref->modname FGR 2 "_"} ^"__to__" ^ {gref->modname MixinName 2 "_"},
      if-verbose (coq.say "HB: declare" Name),
      log.coq.env.add-const-noimplicits Name Bo Ty @transparent! C),
   if (MakeCanon = tt, whd (global (const C)) [] (global (indc _)) _)

--- a/HB/instance.elpi
+++ b/HB/instance.elpi
@@ -44,7 +44,7 @@ declare-const Name BodySkel TyWPSkel :- std.do! [
   private.hack-section-discharging SectionBody SectionBodyHack,
   private.optimize-body SectionBodyHack OptimizedBody,
   if (Name = "_") (RealName is "HB_unnamed_factory_" ^ {std.any->string {new_int} }) (RealName = Name),
-  log.coq.env.add-const-noimplicits RealName OptimizedBody SectionTy @transparent! C,
+  log.coq.env.add-const-noimplicits-failondup RealName OptimizedBody SectionTy @transparent! C,
   TheFactory = (global (const C)),
 
   % call HB.instance TheType TheFactory

--- a/HB/structure.elpi
+++ b/HB/structure.elpi
@@ -293,10 +293,10 @@ declare-coercion SortProjection ClassProjection
 
   log.coq.env.accumulate current "hb.db" (clause _ _ (sub-class FC TC)),
 
-  gref->modname StructureF ModNameF,
-  gref->modname StructureT ModNameT,
-  CName is ModNameF ^ "_class_to_" ^ ModNameT ^ "_class_" ^ {std.any->string {new_int}},
-  SName is ModNameF ^ "_to_" ^ ModNameT ^ "_" ^ {std.any->string {new_int}},
+  gref->modname StructureF 2 "_" ModNameF,
+  gref->modname StructureT 2 "_" ModNameT,
+  CName is ModNameF ^ "_class__to__" ^ ModNameT ^ "_class",
+  SName is ModNameF ^ "__to__" ^ ModNameT,
 
   if-verbose (coq.say "HB: declare coercion" SName),
 
@@ -377,8 +377,8 @@ join-body N1 N2 S3 S2_Pack S1_sort S3_to_S1 S2_class S3_to_S2
 
 pred declare-join i:class, i:pair class class, o:prop.
 declare-join (class C3 S3 MLwP3) (pr (class C1 S1 _) (class C2 S2 _)) (join C1 C2 C3) :-
-  Name is "join_" ^ {gref->modname S3} ^
-    "_between_" ^ {gref->modname S1} ^ "_and_" ^ {gref->modname S2} ^ "_" ^ {std.any->string {new_int}},
+  Name is "join_" ^ {gref->modname S3 2 "_"} ^
+    "_between_" ^ {gref->modname S1 2 "_"} ^ "_and_" ^ {gref->modname S2 2 "_"},
 
   get-structure-coercion S3 S2 S3_to_S2,
   get-structure-coercion S3 S1 S3_to_S1,
@@ -420,7 +420,7 @@ declare-unification-hints SortProj ClassProj CurrentClass NewJoins :- std.do! [
 pred synthesize-fields i:term, i:list (w-args mixinname), o:record-decl.
 synthesize-fields _T []     end-record.
 synthesize-fields T  [triple M Args _|ML] (field _ Name MTy Fields) :- std.do! [
-  Name is {gref->modname M} ^ "_mixin",
+  Name is {gref->modname M 2 "_"} ^ "_mixin",
   if-verbose (coq.say "HB: typing class field" M),
   std.assert! (synthesis.infer-all-mixin-args Args T M MTy) "anomaly: a field type cannot be solved",
   @pi-decl `m` MTy m\ mixin-src T M m => synthesize-fields T ML (Fields m)

--- a/structures.v
+++ b/structures.v
@@ -183,6 +183,7 @@ pred current-mode o:declaration.
 % library, nice-name, object
 pred module-to-export   o:string, o:id, o:modpath.
 pred instance-to-export o:string, o:id, o:constant.
+pred abbrev-to-export   o:string, o:id, o:gref.
 
 % coercions chains compression rules (we only care about non applicative
 % terms, since this is what you get when you apply coercions)
@@ -522,12 +523,21 @@ Elpi Export HB.end.
 
 (** [HB.export Modname] does the work of [Export Modname] but also schedules [Modname]
    to be exported later on, when [HB.reexport] is called.
-   Note that the list of modules to be exported is stored in the current module,
+   [HB.export Constname] does nothing, but schedules [Constname] to be made
+   available via a Notation at HB.reexport time.
+
+   Note that the list of things to be exported is stored in the current module,
    hence the recommended way to do is
 [[
 Module Algebra.
   HB.mixin .... HB.structure ...
   Module MoreExports. ... End MoreExports. HB.export MoreExports.
+  ...
+  HB.builders ...
+  Lemma aux_fact : ....
+  HB.export aux_fact.
+  ...
+  HB.end.
   ...
   Module Export. HB.reexport. End Exports.
 End Algebra.
@@ -547,7 +557,7 @@ Elpi Accumulate File "HB/common/database.elpi".
 Elpi Accumulate File "HB/export.elpi".
 Elpi Accumulate Db hb.db.
 Elpi Accumulate lp:{{
-main [str M] :- !, with-attributes (with-logging (export.module M {coq.locate-module M})).
+main [str M] :- !, with-attributes (with-logging (export.any M)).
 main _ :- coq.error "Usage: HB.export M.".
 }}.
 Elpi Typecheck.
@@ -557,7 +567,8 @@ Elpi Export HB.export.
 (* %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% *)
 (* %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% *)
 
-(** [HB.reexport] Exports all modules that were previously exported via [HB.export].
+(** [HB.reexport] Exports all modules, canonical instances and constants that
+   were previously exported via [HB.export].
    It is useful to create one big module with all exports at the end of a file.
    It optionally takes the name of a module or a component of the current module path
    (a module which is not closed yet) *)

--- a/tests/compress_coe.v
+++ b/tests/compress_coe.v
@@ -34,4 +34,4 @@ HB.instance Definition prodD (D D' : D.type) :=
   hasD.Build (D * D')%type (d, d).
 
 Set Printing Coercions.
-Print prod_canonical_D_34.
+Print Datatypes_prod__canonical__compress_coe_D.

--- a/tests/compress_coe.v.out
+++ b/tests/compress_coe.v.out
@@ -1,13 +1,19 @@
-prod_canonical_D_34 = 
+Datatypes_prod__canonical__compress_coe_D = 
 fun D D' : D.type =>
 {|
   D.sort := D.sort D * D.sort D';
   D.class :=
     {|
-      D.hasA_mixin := prodA (D_to_A_17 D) (D_to_A_17 D');
-      D.hasB_mixin := prodB tt (D_to_B_19 D) (D_to_B_19 D');
-      D.hasC_mixin := prodC tt tt (D_to_C_21 D) (D_to_C_21 D');
-      D.hasD_mixin := prodD D D'
+      D.compress_coe_hasA_mixin :=
+        prodA (compress_coe_D__to__compress_coe_A D)
+          (compress_coe_D__to__compress_coe_A D');
+      D.compress_coe_hasB_mixin :=
+        prodB tt (compress_coe_D__to__compress_coe_B D)
+          (compress_coe_D__to__compress_coe_B D');
+      D.compress_coe_hasC_mixin :=
+        prodC tt tt (compress_coe_D__to__compress_coe_C D)
+          (compress_coe_D__to__compress_coe_C D');
+      D.compress_coe_hasD_mixin := prodD D D'
     |}
 |}
      : D.type -> D.type -> D.type

--- a/tests/exports.v
+++ b/tests/exports.v
@@ -48,6 +48,7 @@ Implicit Type (x : R).
 
 Lemma addr0 : right_id (@zero R) add.
 Proof. by move=> x; rewrite addrC add0r. Qed.
+HB.export addr0.
 
 Lemma addrN : right_inverse (@zero R) opp add.
 Proof. by move=> x; rewrite addrC addNr. Qed.
@@ -57,6 +58,7 @@ Proof. by rewrite addrN. Qed.
 
 Lemma addrNK x y : x + y - y = x.
 Proof. by rewrite -addrA subrr addr0. Qed.
+HB.export addrNK.
 
 End Theory.
 
@@ -78,8 +80,6 @@ End Instances.
 Module Exports.
 #[verbose]
 HB.reexport.
-Definition addrNK := addrNK.
-Definition addr0 := addr0.
 End Exports.
 
 Module ExportsOnlyInstance.
@@ -93,6 +93,7 @@ Module Test1.
 (* We miss the coercions, canonical and elpi metadata *)
 Fail Check forall (R : Enclosing.Ring.type) (x : R), x = x.
 Fail Check 0%G.
+Fail Check addr0.
 
 Export Enclosing.Exports.
 

--- a/tests/exports.v
+++ b/tests/exports.v
@@ -58,9 +58,18 @@ Proof. by rewrite addrN. Qed.
 
 Lemma addrNK x y : x + y - y = x.
 Proof. by rewrite -addrA subrr addr0. Qed.
-HB.export addrNK.
 
 End Theory.
+
+HB.mixin Record Dummy T := { u : unit }.
+HB.structure Definition URing := { R of Ring R & Dummy R }.
+
+HB.factory Record dummy R of Ring R := {}.
+HB.builders Context T of dummy T.
+HB.instance Definition _ := Dummy.Build T tt.
+Definition addrNK := addrNK.
+HB.export addrNK.
+HB.end.
 
 Module Import Instances.
 


### PR DESCRIPTION
The primitive is `gref->modname` which now takes a number of components and a separator.
In this way we can take 2 pieces, eg `GRing_Zmodule`.
Also, add-const ensure fresheness in case of collision, so names are way less borked.
Hb.graph is now working ok.

The decision of taking 2 components is arbitrary, works for MC.