### PR TITLE
Cleanup about locations + HB.locate

### DIFF
--- a/HB/common/log.elpi
+++ b/HB/common/log.elpi
@@ -17,6 +17,12 @@ arguments.set-implicit GR I :-  std.do! [
   log.private.log-vernac (log.private.coq.vernac.implicit Local {coq.gref->id GR} I),
 ].
 
+pred env.add-location i:gref.
+env.add-location GR :-
+  if (get-option "elpi.loc" Loc) % remove when coq-elpi > 1.9
+     (log.coq.env.accumulate current "hb.db" (clause _ _ (decl-location GR Loc)))
+     true.
+
 pred env.add-const-noimplicits i:id, i:term, i:term, i:opaque?, o:constant.
 env.add-const-noimplicits Name Bo Ty Opaque C :- std.do! [
   % TODO: refine when we switch to add-section-variable/add-const
@@ -26,6 +32,7 @@ env.add-const-noimplicits Name Bo Ty Opaque C :- std.do! [
     true,
   avoid-name-collision Name Name1,
   coq.env.add-const Name1 Bo Ty Opaque C,
+  env.add-location (const C),
   if (var Ty) (Ty? = none) (Ty? = some Ty),
   log.private.log-vernac (log.private.coq.vernac.definition Name1 Ty? Bo),
   @local! => arguments.set-implicit (const C) [[]],
@@ -40,6 +47,7 @@ env.add-const Name Bo Ty Opaque C :- std.do! [
     true,
   avoid-name-collision Name Name1,
   coq.env.add-const Name1 Bo Ty Opaque C,
+  env.add-location (const C),
   if (var Ty) (Ty? = none) (Ty? = some Ty),
   log.private.log-vernac (log.private.coq.vernac.definition Name1 Ty? Bo),
 ].
@@ -52,6 +60,7 @@ env.add-const-noimplicits-failondup Name Bo Ty Opaque C :- std.do! [
                ":" {coq.term->string Ty} ":=" {coq.term->string Bo})
     true,
   coq.env.add-const Name Bo Ty Opaque C,
+  env.add-location (const C),
   if (var Ty) (Ty? = none) (Ty? = some Ty),
   log.private.log-vernac (log.private.coq.vernac.definition Name Ty? Bo),
   @local! => arguments.set-implicit (const C) [[]],
@@ -79,13 +88,14 @@ env.add-indt Decl I :- std.do! [
     true,
   coq.env.add-indt Decl I,
   log.private.log-vernac (log.private.coq.vernac.inductive Decl),
+  env.add-location (indt I),
 
   % copy the current value of implicit arguments
   coq.env.indt I _ _ _ _ KS _,
   log.private.log-implicits-of ff (indt I),
-  std.forall KS (k\ log.private.log-implicits-of ff (indc k)),
+  std.forall KS (k\ env.add-location (indc k), log.private.log-implicits-of ff (indc k)),
   std.forall {coq.CS.canonical-projections I}
-    (p\ sigma c\ if (p = some c) (log.private.log-implicits-of ff (const c)) true),
+    (p\ sigma c\ if (p = some c) (env.add-location (const c), log.private.log-implicits-of ff (const c)) true),
 ].
 
 pred env.begin-module i:id, i:option (pair modtypath id).

--- a/HB/factory.elpi
+++ b/HB/factory.elpi
@@ -294,10 +294,6 @@ declare-mixin-or-factory Sort1 Fields GRFSwP Module TheType D TheParams :- std.d
   log.coq.env.accumulate current "hb.db" (clause _ _ (factory-constructor (indt R) GRK)),
   log.coq.env.accumulate current "hb.db" (clause _ _ (factory-builder-nparams BuildConst NParams)),
   log.coq.env.accumulate current "hb.db" (clause _ _ (phant-abbrev GRK (const BuildConst) BuildAbbrev)),
-  if (get-option "elpi.loc" Loc) % remove when coq-elpi > 1.9
-     (log.coq.env.accumulate current "hb.db" (clause _ _ (decl-location GRK Loc)),
-      log.coq.env.accumulate current "hb.db" (clause _ _ (decl-location (indt R) Loc)))
-     true,
   log.coq.env.end-module-name "Exports" Exports,
   log.coq.env.end-module-name Module _,
 

--- a/HB/instance.elpi
+++ b/HB/instance.elpi
@@ -98,10 +98,6 @@ declare-all T [class Class Struct MLwP|Rest] [pr Name CS|L] :-
   log.coq.env.add-const-noimplicits Name S STy @transparent! CS, % Bug coq/coq#11155, could be a Let
   with-locality (log.coq.CS.declare-instance CS), % Bug coq/coq#11155, should be local
 
-  if (get-option "elpi.loc" Loc) % remove when coq-elpi > 1.9
-     (log.coq.env.accumulate current "hb.db" (clause _ _ (decl-location (const CS) Loc)))
-     true,
-
   Clauses => declare-all T Rest L.
 declare-all T [_|Rest] L :- declare-all T Rest L.
 declare-all _ [] [].

--- a/HB/structure.elpi
+++ b/HB/structure.elpi
@@ -88,14 +88,6 @@ declare Module B :- std.do! [
   std.forall NewClauses (c\ log.coq.env.accumulate current "hb.db" (clause _ _ c)),
 
 
-  if (get-option "elpi.loc" Loc) % remove when coq-elpi > 1.9
-     (log.coq.env.accumulate current "hb.db" (clause _ _ (decl-location Structure Loc)),
-      log.coq.env.accumulate current "hb.db" (clause _ _ (decl-location (indt ClassInd) Loc)),
-      log.coq.env.accumulate current "hb.db" (clause _ _ (decl-location (indc ClassK) Loc)),
-      SortProjection = global SortProjectionGR,
-      log.coq.env.accumulate current "hb.db" (clause _ _ (decl-location SortProjectionGR Loc)))
-     true,
-
   if-verbose (coq.say "HB: stop module Exports"),
   log.coq.env.end-module-name "Exports" Exports,
 
@@ -169,7 +161,6 @@ infer-coercion-tgt (w-params.nil _ _ _) _ :- coq.error "TODO1".
 % Po P1 .. PM T M1 .. MN PoArgs -> C P1 .. PM S PoArgs
 pred clean-op-ty i:list prop, i:term, i:term, o:term.
 clean-op-ty [] _ T1 T2 :- copy T1 T2.
-clean-op-ty [decl-location _ _|Ops] S T1 T2 :- clean-op-ty Ops S T1 T2.
 clean-op-ty [exported-op _ Po C|Ops] S T1 T2 :-
   gref-deps (const Po) MLwP,
   w-params.nparams MLwP NParams,
@@ -222,11 +213,7 @@ export-1-operation M Struct Psort Pclass MwP (some Poperation) EXI EXO :- !, std
   std.map {std.iota NImplicits} (_\r\ r = maximal) Implicits,
   @global! => log.coq.arguments.set-implicit (const C) [Implicits],
 
-  if (get-option "elpi.loc" Loc) % remove when coq-elpi > 1.9
-     (LOC_EXI = [decl-location (const C) Loc|EXI])
-     (LOC_EXI = EXI),
-
-  EXO = [exported-op M Poperation C|LOC_EXI]
+  EXO = [exported-op M Poperation C|EXI]
 ].
 
 % Given a list of mixins, it exports all operations in there

--- a/README.md
+++ b/README.md
@@ -131,15 +131,23 @@ opam install coq-hierarchy-builder
   - `HB.builders` and `HB.end` declare a set of builders
   - `HB.instance` declares a structure instance
 
-- HB support commands:
+- HB utility commands:
   - `HB.export` exports a module and schedules it for re-export
-  - `HB.reexport` exports all modules and instances scheduled for re-export
-  - `HB.lock` locks a definition behind a symbol and an unfolding equation
+  - `HB.reexport` exports all modules, instances and constants scheduled for
+    re-export
+  - `HB.lock` locks a definition behind an opaque symbol and an unfolding
+    equation using Coq module system
+
+- HB queries:
+  - `HB.about` is similar to `About` but prints more info on HB structures, like
+    the known instances and where they are declared
+  - `HB.locate` is similar to `Locate`, prints file name and line of any global
+    constant synthesized by HB
   - `HB.graph` prints the structure hierarchy to a dot file
+
+- HB debug commands:
   - `HB.status` dumps the contents of the hierarchy (debug purposes)
-  - `HB.about` is similar to `About` but prints more info on HB structures
-  - `HB.locate` is similar to `Locate`, prints file name and line
-  - `HB.check` is similar to `Check` (test purposes)
+  - `HB.check` is similar to `Check` (testing purposes)
 
 The documentation of all commands can be found in the comments of
 [structures.v](structures.v), search for `Elpi Command` and you will

--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ opam install coq-hierarchy-builder
   - `HB.lock` locks a definition behind a symbol and an unfolding equation
   - `HB.graph` prints the structure hierarchy to a dot file
   - `HB.status` dumps the contents of the hierarchy (debug purposes)
+  - `HB.about` is similar to `About` but prints more info on HB structures
+  - `HB.locate` is similar to `Locate`, prints file name and line
   - `HB.check` is similar to `Check` (test purposes)
 
 The documentation of all commands can be found in the comments of

--- a/structures.v
+++ b/structures.v
@@ -187,7 +187,7 @@ pred module-to-export   o:string, o:id, o:modpath.
 pred instance-to-export o:string, o:id, o:constant.
 pred abbrev-to-export   o:string, o:id, o:gref.
 
-%% database for HB.about %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% database for HB.locate and HB.about %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 pred decl-location o:gref, o:loc.
 
@@ -205,6 +205,31 @@ compress (app L) (app L1) :- !, std.map L compress L1.
 compress X X.
 
 }}.
+
+(* %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% *)
+(* %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% *)
+(* %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% *)
+
+(** This is like Locate but tells you the file and line at which the constant
+    or inductive was generated.
+*)
+
+Elpi Command HB.locate.
+Elpi Accumulate Db hb.db.
+Elpi Accumulate lp:{{
+
+main _ :- coq.version _ _ N _, N < 13, !,
+  coq.say "HB: HB.locate requires Coq version 8.13 or above".
+main [str S] :- !,
+  if (decl-location {coq.locate S} Loc)
+     (coq.say "HB: synthesized in file" Loc)
+     (coq.say "HB:" S "not synthesized by HB").
+
+main _ :- coq.error "Usage: HB.about <name>.".
+}}.
+Elpi Typecheck.
+Elpi Export HB.locate.
+
 
 (* %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% *)
 (* %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% *)

--- a/tests/about.v
+++ b/tests/about.v
@@ -47,3 +47,5 @@ HB.about hierarchy_5_Ring__to__hierarchy_5_SemiRing.
 
 (* builder *)
 HB.about Builders_15.hierarchy_5_Ring_of_AddAG__to__hierarchy_5_BiNearRing_of_AddMonoid.
+
+HB.locate BinNums_Z__canonical__hierarchy_5_AddAG.

--- a/tests/about.v.out
+++ b/tests/about.v.out
@@ -113,10 +113,14 @@ HB: Z is canonically equipped with mixins:
       (from "./tests/about.v", line 8)
 
 HB: hierarchy_5_Ring_class__to__hierarchy_5_SemiRing_class is a coercion from
-    hierarchy_5.Ring to hierarchy_5.SemiRing 
+    hierarchy_5.Ring to hierarchy_5.SemiRing
+    (from "./examples/demo1/hierarchy_5.v", line 200)
 
 HB: hierarchy_5_Ring__to__hierarchy_5_SemiRing is a coercion from
-    hierarchy_5.Ring to hierarchy_5.SemiRing 
+    hierarchy_5.Ring to hierarchy_5.SemiRing
+    (from "./examples/demo1/hierarchy_5.v", line 200)
 
 HB: todo HB.about for builder from hierarchy_5.Ring_of_AddAG to 
 hierarchy_5.BiNearRing_of_AddMonoid
+HB: synthesized in file 
+./tests/about.v, characters 118-242, line 3, column 165


### PR DESCRIPTION
We move all code storing locations in the logging module, and we export HB.locate to know where stuff synthesized by HB is located