### PR TITLE
make direct mixins opaque

### DIFF
--- a/.nix/coq-overlays/coq-elpi/default.nix
+++ b/.nix/coq-overlays/coq-elpi/default.nix
@@ -12,7 +12,7 @@ in mkCoqDerivation {
   owner = "LPCIC";
   inherit version;
   defaultVersion = lib.switch coq.coq-version [
-    { case = "8.13"; out = "1.9.7"; }
+    { case = "8.13"; out = "master"; }
     { case = "8.12"; out = "1.8.3_8.12"; }
     { case = "8.11"; out = "1.6.3_8.11"; }
   ] null;

--- a/HB/common/log.current.elpi
+++ b/HB/common/log.current.elpi
@@ -38,7 +38,7 @@ shorten log.private.coq.vernac.{ begin-module-type , end-module-type }.
 shorten log.private.coq.vernac.{ import-module , export-module }.
 shorten log.private.coq.vernac.{ definition , variable , comment , check }.
 shorten log.private.coq.{ vernac.inductive , vernac.implicit , vernac.parameter }.
-shorten log.private.coq.vernac.{ canonical , abbreviation , notation , coercion }.
+shorten log.private.coq.vernac.{ canonical , abbreviation , notation , coercion , strategy }.
 shorten log.private.{ coq.vernac }.
 shorten coq.pp.{ box , h , spc , v , str , hv , hov, glue, brk }.
 
@@ -111,6 +111,13 @@ coq.vernac->pp1 (comment A) (box (hov 2) [str"(*", str S, str"*)"]) :-
 coq.vernac->pp1 (check T Fail) (box (hov 2) [Failure, str"Check", spc, PPT, str"."]) :-
   @holes! => coq.term->pp T PPT,
   fail->failure Fail Failure.
+coq.vernac->pp1 (strategy L opaque) (box (hov 2) [str"Strategy opaque [", glue PPL , str"]."]) :-
+  std.map L (c\r\sigma id\coq.gref->id (const c) id, r = str id) LID, std.intersperse spc LID PPL.
+coq.vernac->pp1 (strategy L expand) (box (hov 2) [str"Strategy expand [", glue PPL , str"]."]) :-
+  std.map L (c\r\sigma id\coq.gref->id (const c) id, r = str id) LID, std.intersperse spc LID PPL.
+coq.vernac->pp1 (strategy L (level N)) (box (hov 2) [str"Strategy ",str NPP,str" [", glue PPL , str"]."]) :-
+  std.any->string N NPP,
+  std.map L (c\r\sigma id\coq.gref->id (const c) id, r = str id) LID, std.intersperse spc LID PPL.
 
 pred local->locality i:bool, o:coq.pp.
 local->locality tt (str "Local ").

--- a/HB/common/log.elpi
+++ b/HB/common/log.elpi
@@ -23,6 +23,11 @@ env.add-location GR :-
      (log.coq.env.accumulate library "hb.db" (clause _ _ (decl-location GR Loc)))
      true.
 
+pred strategy.set i:list constant, i:conversion_strategy.
+strategy.set CL S :-
+  coq.strategy.set CL S,
+  log.private.log-vernac (log.private.coq.vernac.strategy CL S).
+
 pred env.add-const-noimplicits i:id, i:term, i:term, i:opaque?, o:constant.
 env.add-const-noimplicits Name Bo Ty Opaque C :- std.do! [
   % TODO: refine when we switch to add-section-variable/add-const
@@ -230,6 +235,7 @@ type coq.vernac.canonical     string -> bool                -> coq.vernac.
 type coq.vernac.implicit      bool -> string -> list (list implicit_kind)  -> coq.vernac.
 type coq.vernac.comment       A                             -> coq.vernac.
 type coq.vernac.check         term -> bool                  -> coq.vernac.
+type coq.vernac.strategy      list constant -> conversion_strategy -> coq.vernac.
 
 }
 

--- a/HB/common/log.elpi
+++ b/HB/common/log.elpi
@@ -20,7 +20,7 @@ arguments.set-implicit GR I :-  std.do! [
 pred env.add-location i:gref.
 env.add-location GR :-
   if (get-option "elpi.loc" Loc) % remove when coq-elpi > 1.9
-     (log.coq.env.accumulate current "hb.db" (clause _ _ (decl-location GR Loc)))
+     (log.coq.env.accumulate library "hb.db" (clause _ _ (decl-location GR Loc)))
      true.
 
 pred env.add-const-noimplicits i:id, i:term, i:term, i:opaque?, o:constant.

--- a/HB/instance.elpi
+++ b/HB/instance.elpi
@@ -91,7 +91,7 @@ declare-all T [class Class Struct MLwP|Rest] [pr Name CS|L] :-
   if-verbose (coq.say "HB: declare canonical structure instance" Name),
 
   get-constructor Struct KS,
-  private.optimize-class-body {std.length Params} KCApp KCAppNames Clauses,
+  private.optimize-class-body TGR {std.length Params} KCApp KCAppNames Clauses,
   coq.mk-app (global KS) {std.append Params [T, KCAppNames]} S,
   std.assert-ok! (coq.typecheck S STy) "declare-all: S illtyped",
 
@@ -224,13 +224,15 @@ optimize-body (app[global (const C)| Args]) Red :- (phant-abbrev _ (const C) _ ;
 optimize-body (let _ _ T x\x) Red :- !, optimize-body T Red.
 optimize-body X X.
 
-pred optimize-class-body i:int, i:term, o:term, o:list prop.
-optimize-class-body NParams (let _ _ MBo R) R1 Clauses :- std.do! [
+pred optimize-class-body i:gref, i:int, i:term, o:term, o:list prop.
+optimize-class-body TGR NParams (let _ _ MBo R) R1 Clauses :- std.do! [
   declare-mixin-name MBo (pr MC CL1),
-  optimize-class-body NParams (R MC) R1 CL2,
+  if (TGR = indt _, MC = global (const C), not(coq.env.const-opaque? C))
+     (coq.strategy.set [C] (level 1000)) true, % opaque stops simpl
+  optimize-class-body TGR NParams (R MC) R1 CL2,
   std.append CL1 CL2 Clauses,
 ].
-optimize-class-body _ (app L) (app L) [].
+optimize-class-body _ _ (app L) (app L) [].
 
 pred declare-mixin-name i:term, o:(pair term (list prop)).
 declare-mixin-name (global GR) (pr (global GR) []).

--- a/HB/instance.elpi
+++ b/HB/instance.elpi
@@ -228,7 +228,7 @@ pred optimize-class-body i:gref, i:int, i:term, o:term, o:list prop.
 optimize-class-body TGR NParams (let _ _ MBo R) R1 Clauses :- std.do! [
   declare-mixin-name MBo (pr MC CL1),
   if (TGR = indt _, MC = global (const C), not(coq.env.const-opaque? C))
-     (coq.strategy.set [C] (level 1000)) true, % opaque stops simpl
+     (log.coq.strategy.set [C] (level 1000)) true, % opaque stops simpl
   optimize-class-body TGR NParams (R MC) R1 CL2,
   std.append CL1 CL2 Clauses,
 ].

--- a/coq-hierarchy-builder.opam
+++ b/coq-hierarchy-builder.opam
@@ -12,7 +12,7 @@ build: [ [ make "build"]
          [ make "test-suite" ]  # {with-test} waiting https://github.com/coq-community/docker-coq-action/pull/48
        ]
 install: [ make "install" ]
-depends: [ "coq-elpi" {= "1.6.3~8.11" | = "1.8.3~8.12" | (>= "1.9.7" & < "1.10~")} ]
+depends: [ "coq-elpi" {= "1.6.3~8.11" | = "1.8.3~8.12" | (>= "1.9.7" & < "1.10~") | = "dev" } ]
 conflicts: [ "coq-hierarchy-builder-shim" ]
 synopsis: "High level commands to declare and evolve a hierarchy based on packed classes"
 description: """


### PR DESCRIPTION
from
```
real	12m36,750s
user	31m43,786s
sys	0m22,771s
```
to
```
real	11m57,060s
user	28m7,674s
sys	0m22,622s
```

Depends on https://github.com/LPCIC/coq-elpi/pull/237