### PR TITLE
Remove universe constraint between unify, option and prod

### DIFF
--- a/HB/common/phant-abbreviation.elpi
+++ b/HB/common/phant-abbreviation.elpi
@@ -72,7 +72,7 @@ pred fun-unify i:option term, i:term, i:term, i:phant-term, o:phant-term.
 fun-unify OMsg X1 X2 (private.phant-term AL F) (private.phant-term [private.unify|AL] UF) :-
   std.assert-ok! (coq.typecheck X1 T1) "fun-unify: X1 illtyped",
   std.assert-ok! (coq.typecheck X2 T2) "fun-unify: X2 illtyped",
-  if (OMsg = some M) (Msg = {{lib:hb.some lp:M}}) (Msg = {{lib:hb.nomsg}}),
+  if (OMsg = some M) (Msg = {{lib:hb.not_a_msg lp:M}}) (Msg = {{lib:hb.nomsg}}),
   UF = {{fun unif_arbitrary : lib:hb.unify lp:T1 lp:T2 lp:X1 lp:X2 lp:Msg => lp:F}}.
 
 % [fun-implicit N T Ph Ph1] Adds an implicit argument name N of type T areound Ph
@@ -158,7 +158,7 @@ phant-fun-struct T Name S Params PF Out :- std.do! [
   mk-app (global S) Params SParams,
   mk-app SortProj Params SortProjParams,
   % Msg = {{lib:hb.nomsg}},
-  Msg = some {{lib:hb.pair lib:hb.not_a_msg lp:SParams}},
+  Msg = some {{lp:SParams}},
   (@pi-decl Name SParams s\ fun-unify Msg T {mk-app SortProjParams [s]} (PF s) (UnifSI s)),
   fun-implicit Name SParams UnifSI Out
 ].

--- a/examples/Coq2020_material/CoqWS_expansion/withoutHB.v
+++ b/examples/Coq2020_material/CoqWS_expansion/withoutHB.v
@@ -6,7 +6,7 @@ Set Warnings "-redundant-canonical-projection".
 (* Helpers *)
 Notation "[unify t1 'with' t2 ]" := (unify _ _ t1 t2 _)
   (at level 0, format "[unify  t1  'with'  t2 ]", only printing).
-Notation "[unify t1 'with' t2 ]" := (unify _ _ t1 t2 None)
+Notation "[unify t1 'with' t2 ]" := (unify _ _ t1 t2 NoMsg)
   (at level 0, format "[unify  t1  'with'  t2 ]", only parsing).
 
 Module CMonoid_of_Type.

--- a/structures.v
+++ b/structures.v
@@ -2,11 +2,12 @@
 From Coq Require Import String ssreflect ssrfun.
 Export String.StringSyntax.
 
-Definition unify T1 T2 (t1 : T1) (t2 : T2) (s : option (string * Type)) :=
+Variant error_msg := NoMsg | IsNotCanonicallyA (x : Type).
+Definition unify T1 T2 (t1 : T1) (t2 : T2) (s : error_msg) :=
   phantom T1 t1 -> phantom T2 t2.
 Definition id_phant {T} {t : T} (x : phantom T t) := x.
-Definition nomsg : option (string * Type) := None.
-Definition is_not_canonically_a : string := "is not canonically a".
+Definition nomsg : error_msg := NoMsg.
+Definition is_not_canonically_a x := IsNotCanonicallyA x.
 Definition new {T} (x : T) := x.
 Definition eta {T} (x : T) := x.
 


### PR DESCRIPTION
```Coq
Print Universes Subgraph (unify.u2 option.u0 prod.u1).
```
gave
```
unify.u2 < option.u0
         < prod.u1
```
and those constraint then dripped on every structures.
This became an issue when porting CoqEAL refinements.
We thus use a specific sum type instead of option and prod.