### PR TITLE
Factory sort tactic

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,10 @@ jobs:
         opam_file: './coq-hierarchy-builder.opam'
         coq_version: ${{ matrix.coq_version }}
         ocaml_version: ${{ matrix.ocaml_version }}
-
+      export: 'OPAMWITHTEST'  # space-separated list of variables
+    env:
+      OPAMWITHTEST: 'true'
+      
   plan-B:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,9 +27,9 @@ jobs:
         opam_file: './coq-hierarchy-builder.opam'
         coq_version: ${{ matrix.coq_version }}
         ocaml_version: ${{ matrix.ocaml_version }}
-      export: 'OPAMWITHTEST'  # space-separated list of variables
-    env:
-      OPAMWITHTEST: 'true'
+        export: 'OPAMWITHTEST'  # space-separated list of variables
+      env:
+        OPAMWITHTEST: 'true'
       
   plan-B:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
           cp -ra . /home/coq/workspace
           cd /home/coq/workspace
           opam install ./coq-hierarchy-builder.opam
-          sed -i.bak "s/-Q . HB//" _CoqProject.test-suite
+          sed -i.bak -e "s/-Q . HB//" -e "s|tests/factory_sort_tac.v||" _CoqProject.test-suite
           # This is what a user does to cut HB loose
           export COQ_ELPI_ATTRIBUTES="hb(log(raw))"
           make test-suite -j2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
         coq_version:
           - '8.13'
         ocaml_version:
-          - 'minimal'
+          - '4.07-flambda'
     steps:
     - uses: actions/checkout@v2
     - uses: coq-community/docker-coq-action@v1
@@ -39,7 +39,7 @@ jobs:
       with:
         opam_file: './coq-hierarchy-builder.opam'
         coq_version: '8.13'
-        ocaml_version: 'minimal'
+        ocaml_version: '4.07-flambda'
         script: |
           mkdir /home/coq/workspace
           cp -ra . /home/coq/workspace

--- a/.nix/config.nix
+++ b/.nix/config.nix
@@ -3,7 +3,7 @@
   attribute = "hierarchy-builder";
   default-bundle = "coq-8.13";
   bundles = let common = {
-      mathcomp.override.version = "hierarchy-builder";
+      mathcomp.override.version = "hierarchy-builder+factory_sort_tac";
       mathcomp.job = false;
       mathcomp-single.job = true;
       coq-elpi.override.version = "#257";

--- a/.nix/config.nix
+++ b/.nix/config.nix
@@ -6,6 +6,7 @@
       mathcomp.override.version = "hierarchy-builder";
       mathcomp.job = false;
       mathcomp-single.job = true;
+      coq-elpi.override.version = "#257";
   }; in {
     "coq-8.13".coqPackages = {
       coq.override.version = "8.13";

--- a/.nix/coq-overlays/coq-elpi/default.nix
+++ b/.nix/coq-overlays/coq-elpi/default.nix
@@ -4,7 +4,7 @@ with builtins; with lib; let
   elpi = coq.ocamlPackages.elpi.override (lib.switch coq.coq-version [
     { case = "8.11"; out = { version = "1.11.4"; };}
     { case = "8.12"; out = { version = "1.12.0"; };}
-    { case = "8.13"; out = { version = "1.13.5"; };}
+    { case = "8.13"; out = { version = "1.13.6"; };}
   ] {});
 in mkCoqDerivation {
   pname = "elpi";
@@ -12,10 +12,11 @@ in mkCoqDerivation {
   owner = "LPCIC";
   inherit version;
   defaultVersion = lib.switch coq.coq-version [
-    { case = "8.13"; out = "1.10.2"; }
+    { case = "8.13"; out = "1.10.3"; }
     { case = "8.12"; out = "1.8.3_8.12"; }
     { case = "8.11"; out = "1.6.3_8.11"; }
   ] null;
+  release."1.10.3".sha256      = "";
   release."1.10.2".sha256      = "02jjxq91dr5fybkyf4dwz5hlrwxij7jbgqka2d48s0aivvsk3hbi";
   release."1.10.1".sha256      = "1zsyx26dvj7pznfd2msl2w7zbw51q1nsdw0bdvdha6dga7ijf7xk";
   release."1.9.7".sha256      = "0rvn12h9dpk9s4pxy32p8j0a1h7ib7kg98iv1cbrdg25y5vs85n1";

--- a/.nix/coq-overlays/coq-elpi/default.nix
+++ b/.nix/coq-overlays/coq-elpi/default.nix
@@ -4,7 +4,7 @@ with builtins; with lib; let
   elpi = coq.ocamlPackages.elpi.override (lib.switch coq.coq-version [
     { case = "8.11"; out = { version = "1.11.4"; };}
     { case = "8.12"; out = { version = "1.12.0"; };}
-    { case = "8.13"; out = { version = "1.13.6"; };}
+    { case = "8.13"; out = { version = "v1.13.6"; };}
   ] {});
 in mkCoqDerivation {
   pname = "elpi";
@@ -16,7 +16,7 @@ in mkCoqDerivation {
     { case = "8.12"; out = "1.8.3_8.12"; }
     { case = "8.11"; out = "1.6.3_8.11"; }
   ] null;
-  release."1.10.3".sha256      = "";
+  release."1.10.3".sha256      = "0zxhyhykg36d3jh2kmdpvs58w5ni7mnyzvxvzrprbg7q2kbw6p23";
   release."1.10.2".sha256      = "02jjxq91dr5fybkyf4dwz5hlrwxij7jbgqka2d48s0aivvsk3hbi";
   release."1.10.1".sha256      = "1zsyx26dvj7pznfd2msl2w7zbw51q1nsdw0bdvdha6dga7ijf7xk";
   release."1.9.7".sha256      = "0rvn12h9dpk9s4pxy32p8j0a1h7ib7kg98iv1cbrdg25y5vs85n1";

--- a/HB/about.elpi
+++ b/HB/about.elpi
@@ -48,7 +48,9 @@ main-located S (loc-gref GR) :-
   std.filter {coq.CS.db-for _ (cs-gref GR)} (private.not1 private.unif-hint?) LV,
   coq.CS.db-for GR _ LP,
   std.filter {coq.coercion.db} (c\c = coercion GR _ _ _) LC,
-  if (LV = [], LP = [], LC = []) (coq.error "HB: unknown constant" S) true,
+  if (LV = [], LP = [], LC = [])
+     (coq.error "HB: uninteresting constant" {coq.pp->string {private.pp-loc-of GR}})
+     true,
   if (not (LV = [])) (private.main-canonical-value S LV) true,
   if (not (LP = [])) (private.main-canonical-projection S GR LP) true,
   if (not (LC = [])) (private.main-coercion S LC) true.

--- a/HB/about.elpi
+++ b/HB/about.elpi
@@ -82,8 +82,8 @@ main-canonical-value S CanonicalValues :-
 
 pred group-by-loc i:list cs-instance, o:list (pair (option loc) (list cs-instance)).
 group-by-loc [] [].
-group-by-loc [cs-instance P V (global GR)|L] [pr (some Loc) [cs-instance P V (global GR)|SameLoc]|Rest1] :- decl-location GR Loc, !,
-  std.partition L (x\ sigma GR1\ x = cs-instance _ _ (global GR1), decl-location GR1 Loc) SameLoc Rest,
+group-by-loc [cs-instance P V GR|L] [pr (some Loc) [cs-instance P V GR|SameLoc]|Rest1] :- decl-location GR Loc, !,
+  std.partition L (x\ sigma GR1\ x = cs-instance _ _ GR1, decl-location GR1 Loc) SameLoc Rest,
   group-by-loc Rest Rest1.
 group-by-loc [I|Rest] [pr none [I]|Rest1] :- group-by-loc Rest Rest1.
 
@@ -96,7 +96,7 @@ pp-canonical-solution-list (pr (some Loc) L) Pp :-
                  [ spc, {pp-loc Loc} ] }.
 
 pred pp-canonical-solution i:cs-instance, o:coq.pp.
-pp-canonical-solution (cs-instance _Proj _Pat (global GR)) Pp :-
+pp-canonical-solution (cs-instance _Proj _Pat GR) Pp :-
   coq.env.typeof GR T,
   coq.prod-tgt->gref T F,
   if (class-def (class _ F _)) (gref->modname F 2 "." ID) (coq.gref->string F ID),
@@ -204,7 +204,7 @@ main-factory-constructor S F PhBuild Build :-
   list-w-params_list DMLwP DML,
   factory-provides (indt F) PMLwP,
   list-w-params_list PMLwP PML,
-  coq.CS.canonical-projections F FieldsOpts,
+  coq.env.projections F FieldsOpts,
   std.map-filter FieldsOpts (x\r\ x = some r) Fields,
   coq.arguments.implicit PhBuild [Implicits],
 
@@ -270,7 +270,7 @@ compute-arg-type.fields [OP|Cs] NDeps Args [pr ID PPTy|Xs] [ID|FN] :-
 pred main-factory i:string, i:inductive.
 main-factory S Factory :-
   % fetch
-  coq.CS.canonical-projections Factory Ps,
+  coq.env.projections Factory Ps,
   std.map-filter Ps (x\r\ x = some r) Fields,
   gref-deps (indt Factory) DMLwP,
   list-w-params_list DMLwP DML,

--- a/HB/about.elpi
+++ b/HB/about.elpi
@@ -66,8 +66,7 @@ shorten coq.pp.{ v , h, hv, hov , spc , str , box , glue , brk , empty }.
 
 pred docstring-for-file i:string, o:prop.
 docstring-for-file Rex (docstring Loc Doc) :- docstring Loc Doc,
-  std.any->string Loc LocS,
-  rex.split "," LocS [File|_],
+  loc.fields Loc File _ _ _ _,
   rex.match {calc(".*" ^ Rex)} File.
 
 pred main-canonical-value i:string, i:list cs-instance.
@@ -316,10 +315,8 @@ pp-loc-of _ coq.pp.empty.
 
 pred pp-loc i:loc, o:coq.pp.
 pp-loc Loc (coq.pp.glue PP) :-
-  std.any->string Loc SLoc,
-  % VSCode friendly
-  rex.split "," SLoc [File,_,Line|_],
-  QFile is "\"" ^ File ^ "\"," ^ Line,
+  loc.fields Loc File _ _ Line _,
+  QFile is "\"" ^ File ^ "\", line " ^ {std.any->string Line},
   PP = [str "(from ", str QFile, str")"].
 
 pred docstring->pp i:string, o:coq.pp.

--- a/HB/about.elpi
+++ b/HB/about.elpi
@@ -204,15 +204,14 @@ main-factory-constructor S F PhBuild Build :-
   list-w-params_list DMLwP DML,
   factory-provides (indt F) PMLwP,
   list-w-params_list PMLwP PML,
-  factory-nparams (indt F) NParams,
   coq.CS.canonical-projections F FieldsOpts,
   std.map-filter FieldsOpts (x\r\ x = some r) Fields,
-  std.map Fields (c\r\coq.gref->id (const c) r) FieldsNames,
   coq.arguments.implicit PhBuild [Implicits],
-  std.map {std.iota NParams} std.any->string Params,
-  std.map Params (i\r\r is "P" ^ i) ParamsNames,
+
+  compute-arg-type DMLwP Fields [] ParamsNames TName FieldsNames ArgsTypes,
+  compute-field-info FieldsNames Implicits FieldsNamesInfo,
   std.map ParamsNames (n\r\r = str n) ParamsPp,
-  compute-field-info FieldsNames Implicits FieldsInfo,
+
   % format
   PpOrigin = box (hov 4) [
     str "HB: ", str S, str " is a factory constructor", spc,
@@ -223,11 +222,12 @@ main-factory-constructor S F PhBuild Build :-
   PpProvides = box (v 4) [
     str "HB: ", str S, str " provides the following mixins:",
     {bulletize PML pp-module}],
-  PpUsage = box h {std.intersperse spc [
+  PpUsage = box (v 4) [box h {std.intersperse spc [
     str "HB: arguments:",
     glue {std.intersperse spc [str S | ParamsPp]},
-    str "T",
-    glue FieldsInfo]},
+    str TName,
+    glue FieldsNamesInfo]},
+    {bulletize ArgsTypes pp-arg-type}],
   % print
   coq.say {coq.pp->string PpOrigin},  
   coq.say {coq.pp->string PpRequires},  
@@ -235,6 +235,37 @@ main-factory-constructor S F PhBuild Build :-
   coq.say {coq.pp->string PpUsage},
   print-docstring Build,
   coq.say.
+
+pred compute-arg-type i:list-w-params mixinname, i:list constant, i:list term, o:list id, o:id, o:list id, o:list (pair id coq.pp).
+compute-arg-type (w-params.cons ID Ty Rest) F Acc [ID|PN] TN FN [pr ID PPTy |Xs] :-
+  coq.term->pp Ty PPTy,
+  @pi-parameter ID Ty x\ compute-arg-type (Rest x) F [x|Acc] PN TN FN Xs.
+compute-arg-type (w-params.nil ID Ty Rest) F Acc [] ID FN [pr ID PPTy|Xs] :-
+  coq.term->pp Ty PPTy,
+  @pi-parameter ID Ty x\ compute-arg-type.fields F {std.length (Rest x)} {std.rev [x|Acc]} Xs FN.
+pred compute-arg-type.fields i:list constant, i:int, i:list term, o:list (pair id coq.pp), o:list id.
+compute-arg-type.fields [] _ _ [] [].
+compute-arg-type.fields [C|Cs] NDeps Args [pr ID PPTy|Xs] [ID|FN] :- exported-op _ C OP, !,
+  coq.env.typeof (const OP) Ty,
+  coq.gref->id (const OP) ID,
+  coq.subst-prod Args Ty TyArgs,
+  @pplevel! 200 => coq.term->pp TyArgs PPTy,
+  compute-arg-type.fields Cs NDeps Args Xs FN.
+compute-arg-type.fields [OP|Cs] NDeps Args [pr ID PPTy|Xs] [ID|FN] :-
+  % factories don't get exported ops, so we hack their types :-/
+  coq.env.typeof (const OP) OrigTy,
+  copy OrigTy Ty,
+  coq.gref->id (const OP) ID,
+  coq.subst-prod Args Ty TyArgs,
+  coq.mk-n-holes NDeps Deps,
+  coq.subst-prod Deps TyArgs TyArgsDeps,
+  coq.subst-prod [_] TyArgsDeps TyArgsDepsRecord,
+  ToDrop is NDeps + 2,
+  @pplevel! 200 => coq.term->pp TyArgsDepsRecord PPTy,
+  @pi-parameter ID TyArgsDepsRecord op\
+  (pi L L1 X\
+    copy (app[global(const OP)|L]) X :- std.drop ToDrop L L1, coq.mk-app op L1 X) =>
+    compute-arg-type.fields Cs NDeps Args Xs FN.
 
 pred main-factory i:string, i:inductive.
 main-factory S Factory :-
@@ -295,6 +326,9 @@ pp-module M (str ID) :- gref->modname M 2 "." ID.
 
 pred pp-const i:constant, o:coq.pp.
 pp-const F (str ID) :- coq.gref->id (const F) ID.
+
+pred pp-arg-type i:pair id coq.pp, o:coq.pp.
+pp-arg-type (pr ID PPTy) (box (hov 2) [str ID, str" :", spc, PPTy]).
 
 pred pp-if-verbose o:coq.pp, i:(coq.pp -> prop).
 pp-if-verbose V P :- get-option "verbose" tt, !, P V.

--- a/HB/builders.elpi
+++ b/HB/builders.elpi
@@ -55,8 +55,8 @@ builders.end :- std.do! [
   std.forall Clauses (c\ log.coq.env.accumulate current "hb.db" (clause _ _ c)),
   std.forall ExportClausesFiltered (c\ log.coq.env.accumulate current "hb.db" (clause _ _ c)),
 
-  % Clauses => ExportClausesFiltered => current-mode no-builder =>
-  %   instance.declare-factory-sort-factory GR,
+  Clauses => ExportClausesFiltered => current-mode no-builder =>
+    instance.declare-factory-sort-factory GR,
 
   log.coq.env.end-module-name Name Exports,
   log.coq.env.end-module-name ModName _,

--- a/HB/builders.elpi
+++ b/HB/builders.elpi
@@ -6,23 +6,23 @@ namespace builders {
 pred begin i:context-decl.
 begin CtxSkel :- std.do! [
   Name is "Builders_" ^ {std.any->string {new_int}}, % TODO?
-  if-verbose (coq.say "HB: begin module for builders"),
+  if-verbose (coq.say {header} "begin module for builders"),
   log.coq.env.begin-module Name none,
 
   builders.private.factory CtxSkel IDF GRF,
 
   % the Super module to access operations/axioms shadowed by the ones in the factory
   if (GRF = indt FRecord) (std.do! [
-    if-verbose (coq.say "HB: begin module Super"),
+    if-verbose (coq.say {header} "begin module Super"),
     log.coq.env.begin-module "Super" none,
     std.forall {coq.env.projections FRecord}
       builders.private.declare-shadowed-constant,
     log.coq.env.end-module-name "Super" _,
-    if-verbose (coq.say "HB: ended module Super")
+    if-verbose (coq.say {header} "ended module Super")
   ]) (true),
 
   log.coq.env.begin-section Name,
-  if-verbose (coq.say "HB: postulating factories"),
+  if-verbose (coq.say {header} "postulating factories"),
   builders.private.postulate-factories Name IDF CtxSkel,
 ].
 
@@ -78,10 +78,10 @@ namespace builders.private {
 % From holds the (from F Mi Bi) new clauses during folding.
 pred declare-1-builder i:builder, i:list prop, o:list prop.
 declare-1-builder (builder _ SrcFactory TgtMixin _) FromClauses FromClauses :- FromClauses => from SrcFactory TgtMixin _, !,
-  if-verbose (coq.say "HB: skipping duplicate builder from"
+  if-verbose (coq.say {header} "skipping duplicate builder from"
     {nice-gref->string SrcFactory} "to" {nice-gref->string TgtMixin}).
 declare-1-builder (builder _ SrcFactory TgtMixin B) FromClauses [from SrcFactory TgtMixin B|FromClauses] :-
-  if-verbose (coq.say "HB: declare builder from"
+  if-verbose (coq.say {header} "declare builder from"
     {nice-gref->string SrcFactory} "to" {nice-gref->string TgtMixin}).
 
 % We add breviations for all constants what will be shadowed by projections

--- a/HB/builders.elpi
+++ b/HB/builders.elpi
@@ -15,7 +15,7 @@ begin CtxSkel :- std.do! [
   if (GRF = indt FRecord) (std.do! [
     if-verbose (coq.say "HB: begin module Super"),
     log.coq.env.begin-module "Super" none,
-    std.forall {coq.CS.canonical-projections FRecord}
+    std.forall {coq.env.projections FRecord}
       builders.private.declare-shadowed-constant,
     log.coq.env.end-module-name "Super" _,
     if-verbose (coq.say "HB: ended module Super")
@@ -115,7 +115,7 @@ pred define-factory-operations i:term, i:list term, i:term, i:gref.
 define-factory-operations TheType Params TheFactory (indt I) :- !,
   coq.env.indt I _ NIParams _ _ _ _,
   NHoles is NIParams - 1 - {std.length Params},
-  coq.CS.canonical-projections I PL,
+  coq.env.projections I PL,
   std.forall PL (define-factory-operation TheType Params TheFactory NHoles).
 define-factory-operations _ _ _ _.
 

--- a/HB/builders.elpi
+++ b/HB/builders.elpi
@@ -55,8 +55,8 @@ builders.end :- std.do! [
   std.forall Clauses (c\ log.coq.env.accumulate current "hb.db" (clause _ _ c)),
   std.forall ExportClausesFiltered (c\ log.coq.env.accumulate current "hb.db" (clause _ _ c)),
 
-  Clauses => ExportClausesFiltered => current-mode no-builder =>
-    instance.declare-factory-sort-factory GR,
+  % Clauses => ExportClausesFiltered => current-mode no-builder =>
+  %   instance.declare-factory-sort-factory GR,
 
   log.coq.env.end-module-name Name Exports,
   log.coq.env.end-module-name ModName _,

--- a/HB/common/database.elpi
+++ b/HB/common/database.elpi
@@ -248,14 +248,14 @@ get-structure-coercion S T (global F) :-
 
 pred get-structure-sort-projection i:structure, o:term.
 get-structure-sort-projection (indt S) Proj :- !,
-  coq.CS.canonical-projections S L,
+  coq.env.projections S L,
   if (L = [some P, _]) true (coq.error "No canonical sort projection for" S),
   Proj = global (const P).
 get-structure-sort-projection S _ :- coq.error "get-structure-sort-projection: not a structure" S.
 
 pred get-structure-class-projection i:structure, o:term.
 get-structure-class-projection (indt S) T :- !,
-  coq.CS.canonical-projections S L,
+  coq.env.projections S L,
   if (L = [_, some P]) true (coq.error "No canonical class projection for" S),
   T = global (const P).
 get-structure-class-projection S _ :- coq.error "get-structure-class-projection: not a structure" S.
@@ -267,7 +267,7 @@ get-constructor I _ :- coq.error "get-constructor: not an inductive" I.
 
 %% finding for locally defined structures
 pred get-cs-structure i:cs-instance, o:structure.
-get-cs-structure (cs-instance _ _ (global Inst)) Struct :- std.do! [
+get-cs-structure (cs-instance _ _ Inst) Struct :- std.do! [
   coq.env.typeof Inst InstTy,
   coq.prod-tgt->gref InstTy Struct
 ].
@@ -288,7 +288,7 @@ get-local-structures TyTrm StructL :- std.do! [
 pred local-cs? i:term, i:structure.
 local-cs? TyTerm (indt Struct) :- coq.version _ _ N _, N > 12, !,
   term->gref TyTerm Value,
-  coq.CS.canonical-projections Struct [some Proj, _],
+  coq.env.projections Struct [some Proj, _],
   coq.CS.db-for (const Proj) (cs-gref Value) L,
   not(L = []).
 local-cs? TyTerm Struct :-

--- a/HB/common/log.elpi
+++ b/HB/common/log.elpi
@@ -96,7 +96,7 @@ env.add-indt Decl I :- std.do! [
   coq.env.indt I _ _ _ _ KS _,
   log.private.log-implicits-of ff (indt I),
   std.forall KS (k\ env.add-location (indc k), log.private.log-implicits-of ff (indc k)),
-  std.forall {coq.CS.canonical-projections I}
+  std.forall {coq.env.projections I}
     (p\ sigma c\ if (p = some c) (env.add-location (const c), log.private.log-implicits-of ff (const c)) true),
 ].
 

--- a/HB/common/log.elpi
+++ b/HB/common/log.elpi
@@ -355,9 +355,9 @@ coq.vernac->pp1 (vernac.parameter Name Ty) (box (hv 2) [box h [str "Parameter ",
   coq.term->pp Ty TY.
 coq.vernac->pp1 (import-module Name) (box h [str "Import ", str Name, str "."]).
 coq.vernac->pp1 (export-module Name) (box h [str "Export ", str Name, str "."]).
-coq.vernac->pp1 (notation KM NParams Term) (box (hv 2) [box h [str "Notation \"'",str KM,str"' "|StrParams], str "\" :=", spc, B, str " (at level 1)."]) :- !,
+coq.vernac->pp1 (notation KM NParams Term) (box (hv 2) [box h [str "Notation \"'",str KM,str"' "|StrParams], str "\" := (", spc, B, str ") (at level 1)."]) :- !,
   coq.vernac->ppabbrterm NParams Term StrParams B.
-coq.vernac->pp1 (abbreviation Name NParams Term) (box (hv 2) [box h [str "Notation ",str Name|StrParams], str " :=", spc, B, str "."]) :-
+coq.vernac->pp1 (abbreviation Name NParams Term) (box (hv 2) [box h [str "Notation ",str Name|StrParams], str " := (", spc, B, str ")."]) :-
   coq.vernac->ppabbrterm NParams Term StrParams B.
 coq.vernac->pp1 (canonical Name Local) (box h [Locality, str "Canonical ", str Name, str "."]) :-
   local->locality Local Locality.

--- a/HB/common/log.elpi
+++ b/HB/common/log.elpi
@@ -249,10 +249,11 @@ pred log.private.log-vernac i:log.private.coq.vernac.
 
 with-logging P :- (get-option "elpi.hb.log" _, NICE = tt ; get-option "elpi.hb.log.raw" _, NICE = ff), !,
   get-option "elpi.loc" Loc,
-  rex_split "," Loc [FILE|_],
+  loc.fields Loc FILE _ _ _ _,
+  std.any->string Loc LocStr,
   FILENAME is FILE ^ ".hb",
   open_append FILENAME OC1,
-  std.string.concat "\n" ["","HIERARCHY BUILDER PATCH v1",Loc,""] PATCH1,
+  std.string.concat "\n" ["","HIERARCHY BUILDER PATCH v1",LocStr,""] PATCH1,
   output OC1 PATCH1,
   close_out OC1,
   log.private.logger L NICE => P,

--- a/HB/common/log.elpi
+++ b/HB/common/log.elpi
@@ -196,6 +196,14 @@ log.coq.check Skel Ty T D :- std.do! [
   log.private.log-vernac (log.private.coq.vernac.check Skel Fail),
 ].
 
+pred refine i:term, i:goal, o:list sealed-goal. % to silence a warning, since this is only in tactics
+pred log.refine i:term, i:goal, o:list sealed-goal.
+log.refine T G GL :- std.do! [
+  refine T G GL,
+  G = goal _ _ _ Solution _,
+  log.private.log-tactic Solution,
+].
+
 namespace log.private {
 
 %%%%% Logging Utils %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -241,6 +249,7 @@ type coq.vernac.strategy      list constant -> conversion_strategy -> coq.vernac
 
 pred with-logging i:prop.
 pred log.private.log-vernac i:log.private.coq.vernac.
+pred log.private.log-tactic i:term.
 
 /*        Hierarchy Builder: algebraic hierarchies made easy
     This software is released under the terms of the MIT license              */
@@ -275,6 +284,11 @@ log.private.log-vernac V :- log.private.logger L Nice, !,
   if (Nice = tt) (PPALL = []) (PPALL = [@ppall!]),
   log.private.logger-extend L {PPALL => log.private.coq.vernac->pp [V]}.
 log.private.log-vernac _.
+
+log.private.log-tactic P :- log.private.logger L Nice, !,
+  if (Nice = tt) (PPALL = []) (PPALL = [@ppall!]),
+  log.private.logger-extend L {PPALL => coq.term->pp P}.
+log.private.log-tactic _.
 
 % The main entry point to print vernacular commands is coq.vernac->pp
 

--- a/HB/common/log.elpi
+++ b/HB/common/log.elpi
@@ -203,6 +203,14 @@ log.refine T G GL :- std.do! [
   G = goal _ _ _ Solution _,
   log.private.log-tactic Solution,
 ].
+pred refine.no_check i:term, i:goal, o:list sealed-goal. % to silence a warning, since this is only in tactics
+pred log.refine.no_check i:term, i:goal, o:list sealed-goal.
+log.refine.no_check T G GL :- std.do! [
+  refine.no_check T G GL,
+  G = goal _ _ _ Solution _,
+  log.private.log-tactic Solution,
+].
+
 
 namespace log.private {
 

--- a/HB/common/stdpp.elpi
+++ b/HB/common/stdpp.elpi
@@ -102,7 +102,7 @@ constraint print-ctx mixin-src {
 % approximation, it should be logical path, not the file name
 pred coq.env.current-library o:string.
 coq.env.current-library L :- coq.version _ _ N _, N >= 13, !,
-  rex_split "," {get-option "elpi.loc"} [L|_].
+  loc.fields {get-option "elpi.loc"} L _ _ _ _.
 coq.env.current-library "dummy.v".
 
 pred coq.prod-tgt->gref i:term, o:gref.

--- a/HB/common/synthesis.elpi
+++ b/HB/common/synthesis.elpi
@@ -222,25 +222,21 @@ instantiate-all-args-let F _ F ok.
 % which can be candidates from that class instance
 pred structure-instance->mixin-srcs i:term, i:structure, o:list prop.
 structure-instance->mixin-srcs T S MSLC :- std.do! [
-  get-structure-sort-projection S Sort,
+  structure-key SortProj ClassProj S,
+  class-def (class (indt Class) S _),
   structure-nparams S NParams,
-  coq.mk-n-holes NParams Holes,
-  coq.mk-app Sort {std.append Holes [ST]} SortHolesST,
+  coq.mk-n-holes {calc (NParams + 1)} HolesST,
+  coq.mk-app (global (const SortProj)) HolesST SortHolesST,
   if (coq.unify-eq T SortHolesST ok) (
-    % Hum, this unification problem is not super trivial. TODO replace by something simpler
-    get-constructor S KS,
-    coq.mk-app (global KS) {std.append Holes [T, C]} KSHolesC,
-    std.assert-ok! (coq.unify-eq ST KSHolesC) "HB: structure-instance->mixin-srcs: ST = _ _ C",
-    class-def (class CN S CMLwP),
-    get-constructor CN KC,
-    std.length {list-w-params_list CMLwP} CMixinsN,
-    coq.mk-n-holes CMixinsN MIL,
-    coq.mk-app (global KC) {std.append Holes [T | MIL]} CBody,
-    std.assert-ok! (coq.unify-eq C CBody) "HB: structure-instance->mixin-srcs: C = KC ... T MIL",
+    coq.mk-app (global (const ClassProj)) HolesST ClassST,
+    coq.CS.canonical-projections Class Projs,
+    std.map-filter Projs (structure-instance->mixin-srcs.aux2 {std.take NParams HolesST} T ClassST) MIL,
     std.map MIL (structure-instance->mixin-srcs.aux T) MSLL,
     std.flatten MSLL MSLC)
     (MSLC = [])
 ].
+structure-instance->mixin-srcs.aux2 Params T Class (some P) M :-
+  coq.mk-app (global (const P)) {std.append Params [T,Class]} M.
 structure-instance->mixin-srcs.aux T  F CL :-
   factory-instance->new-mixins [] F ML,
   std.map ML (m\c\ c = mixin-src T m F) CL.

--- a/HB/common/synthesis.elpi
+++ b/HB/common/synthesis.elpi
@@ -150,7 +150,7 @@ namespace private {
 % the databases [mixin-src] and [from]
 pred mixin-for i:term, i:mixinname, o:term.
 mixin-for T M MICompressed :- mixin-src T M Tm, !, std.do! [
-  %if-verbose (coq.say "HB: Trying to infer mixin for" M),
+  %if-verbose (coq.say {header} "Trying to infer mixin for" M),
   std.assert-ok! (coq.typecheck Tm Ty) "mixin-for: Tm illtyped",
 
 %%%%% mterm %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -162,7 +162,7 @@ mixin-for T M MICompressed :- mixin-src T M Tm, !, std.do! [
       coq.subst-fun [Tm] B MI
   ),
 
-  %if-verbose (coq.say "HB: Trying to compress mixin for" {coq.term->string MI}),
+  %if-verbose (coq.say {header} "Trying to compress mixin for" {coq.term->string MI}),
   compress-coercion-paths MI MICompressed,
 ].
 

--- a/HB/common/synthesis.elpi
+++ b/HB/common/synthesis.elpi
@@ -223,16 +223,31 @@ instantiate-all-args-let F _ F ok.
 pred structure-instance->mixin-srcs i:term, i:structure, o:list prop.
 structure-instance->mixin-srcs T S MSLC :- std.do! [
   structure-key SortProj ClassProj S,
-  class-def (class (indt Class) S _),
+  class-def (class (indt Class) S CMLwP),
   structure-nparams S NParams,
-  coq.mk-n-holes {calc (NParams + 1)} HolesST,
+  coq.mk-n-holes NParams Holes,
+  std.append Holes [ST] HolesST,
   coq.mk-app (global (const SortProj)) HolesST SortHolesST,
   if (coq.unify-eq T SortHolesST ok) (
-    coq.mk-app (global (const ClassProj)) HolesST ClassST,
-    coq.CS.canonical-projections Class Projs,
-    std.map-filter Projs (structure-instance->mixin-srcs.aux2 {std.take NParams HolesST} T ClassST) MIL,
-    std.map MIL (structure-instance->mixin-srcs.aux T) MSLL,
-    std.flatten MSLL MSLC)
+
+    % if the structure instance is concrete, we take the parts
+    get-constructor S KS,
+    coq.mk-app (global KS) {std.append Holes [ST, CT]} KSHolesC,
+    if (coq.unify-eq ST KSHolesC ok)
+      (% if the structure instance is concrete, we take the parts
+       get-constructor (indt Class) KC,
+       std.length {list-w-params_list CMLwP} CMixinsN,
+       coq.mk-n-holes CMixinsN MIL,
+       coq.mk-app (global KC) {std.append Holes [T | MIL]} CBody,
+       std.assert-ok! (coq.unify-eq CT CBody) "HB: structure-instance->mixin-srcs: C = KC ... T MIL",
+       std.map MIL (structure-instance->mixin-srcs.aux T) MSLL,
+       std.flatten MSLL MSLC)
+      (% otherwise we project
+       coq.mk-app (global (const ClassProj)) HolesST ClassST,
+       coq.CS.canonical-projections Class Projs,
+       std.map-filter Projs (structure-instance->mixin-srcs.aux2 {std.take NParams HolesST} T ClassST) MIL,
+       std.map MIL (structure-instance->mixin-srcs.aux T) MSLL,
+       std.flatten MSLL MSLC))
     (MSLC = [])
 ].
 structure-instance->mixin-srcs.aux2 Params T Class (some P) M :-

--- a/HB/common/synthesis.elpi
+++ b/HB/common/synthesis.elpi
@@ -35,16 +35,17 @@ infer-all-gref-deps Ps T GR X :- std.do! [
   private.instantiate-all-these-mixin-args FT T ML X,
 ].
 
-% [infer-all-args-let Ps T GR X] fills in all the Args in
+% [infer-all-args-let Ps T GR X Diagnostic] fills in all the Args in
 %   app[global GR, Ps, T | Args]
 % and generates a term
 %   let `a1` ty1 t1 a1\ .... app[global GR, p1, .. pn, T, a1, .. , an]
-pred infer-all-args-let i:list term, i:term, i:gref, o:term.
-infer-all-args-let Ps T GR X :- std.do! [
+% if Diagnostic is ok, else X is unassigned
+pred infer-all-args-let i:list term, i:term, i:gref, o:term, o:diagnostic.
+infer-all-args-let Ps T GR X Diag :- std.do! [
   coq.env.typeof GR Ty,
   coq.mk-eta (-1) Ty (global GR) EtaF,
   coq.subst-fun {std.append Ps [T]} EtaF FT,
-  private.instantiate-all-args-let FT T X,
+  private.instantiate-all-args-let FT T X Diag,
 ].
 
 
@@ -192,7 +193,7 @@ builder->term Ps T Src Tgt B :- !, std.do! [
 % then TFX := fun xs m_0 .. m_{i-1}     m_{i+1} .. m_n ys
 %            => F xs m_0 .. m_{i-1} X_i m_{i+1} .. m_n ys
 % thus instanciating an abstraction on mixin M_i with X_i
-pred instantiate-all-these-mixin-args i:term, i:term, i:list mixinname,o:term.
+pred instantiate-all-these-mixin-args i:term, i:term, i:list mixinname, o:term.
 instantiate-all-these-mixin-args (fun _ Tm F) T ML R :-
   coq.safe-dest-app Tm (global TmGR) _,
   factory-alias->gref TmGR M,
@@ -204,14 +205,17 @@ instantiate-all-these-mixin-args (fun N Ty F) T ML (fun N Ty FX) :- !,
   @pi-decl N Ty m\ instantiate-all-these-mixin-args (F m) T ML (FX m).
 instantiate-all-these-mixin-args F _ _ F.
 
-pred instantiate-all-args-let i:term, i:term, o:term.
-instantiate-all-args-let (fun N Tm F) T (let N Tm X R) :- !, std.do! [
+pred instantiate-all-args-let i:term, i:term, o:term, o:diagnostic.
+instantiate-all-args-let (fun N Tm F) T (let N Tm X R) Diag :- !, std.do! [
   coq.safe-dest-app Tm (global TmGR) _,
   factory-alias->gref TmGR M,
-  mixin-for T M X,
-  (@pi-def N Tm X m\ instantiate-all-args-let (F m) T (R m)),
+  if (mixin-for T M X)
+     (@pi-def N Tm X m\ instantiate-all-args-let (F m) T (R m) Diag)
+     (Diag = error Msg,
+      Msg is "cannot synthesize mixin " ^ {nice-gref->string M} ^
+             " for " ^ {coq.term->string T}),
 ].
-instantiate-all-args-let F _ F.
+instantiate-all-args-let F _ F ok.
 
 % [structure-instance->mixin-srcs TheType Structure] finds a CS instance for
 % Structure on TheType (if any) and builds mixin-src clauses for all the mixins

--- a/HB/common/synthesis.elpi
+++ b/HB/common/synthesis.elpi
@@ -232,7 +232,7 @@ structure-instance->mixin-srcs T S MSLC :- std.do! [
 
     % if the structure instance is concrete, we take the parts
     get-constructor S KS,
-    coq.mk-app (global KS) {std.append Holes [ST, CT]} KSHolesC,
+    coq.mk-app (global KS) {std.append Holes [T, CT]} KSHolesC,
     if (coq.unify-eq ST KSHolesC ok)
       (% if the structure instance is concrete, we take the parts
        get-constructor (indt Class) KC,

--- a/HB/common/synthesis.elpi
+++ b/HB/common/synthesis.elpi
@@ -244,7 +244,7 @@ structure-instance->mixin-srcs T S MSLC :- std.do! [
        std.flatten MSLL MSLC)
       (% otherwise we project
        coq.mk-app (global (const ClassProj)) HolesST ClassST,
-       coq.CS.canonical-projections Class Projs,
+       coq.env.projections Class Projs,
        std.map-filter Projs (structure-instance->mixin-srcs.aux2 {std.take NParams HolesST} T ClassST) MIL,
        std.map MIL (structure-instance->mixin-srcs.aux T) MSLL,
        std.flatten MSLL MSLC))

--- a/HB/common/utils.elpi
+++ b/HB/common/utils.elpi
@@ -50,6 +50,10 @@ pred if-verbose i:prop.
 if-verbose P :- get-option "verbose" tt, !, P.
 if-verbose _.
 
+% header of if-verbose messages
+pred header o:string.
+header Msg :- Msg is "[" ^ {std.any->string {gettimeofday}} ^ "] HB: ".
+
 pred if-arg-sort i:prop.
 if-arg-sort P :- get-option "arg_sort" tt, !, P.
 if-arg-sort _.

--- a/HB/context.elpi
+++ b/HB/context.elpi
@@ -13,7 +13,7 @@ declare FLwP Params TheKey MSL CL :- !, std.do! [
 
 pred declare.params-key i:w-params A, o:list term, o:term, o:A.
 declare.params-key MLwP Params TheKey Out :- !, std.do! [
-  if-verbose (coq.say "HB: declaring parameters and key as section variables"),
+  if-verbose (coq.say {header} "declaring parameters and key as section variables"),
   declare.params MLwP Params KId KTy F,
   log.coq.env.add-section-variable-noimplicits KId KTy C,
   TheKey = global (const C),
@@ -58,7 +58,7 @@ pred postulate-mixin i:w-args mixinname, i:list prop, o:list prop.
 postulate-mixin (triple M Ps T) MSL [mixin-src T M (global (const C))|MSL] :- MSL => std.do! [
   Name is "local_mixin_" ^ {gref->modname M 2 "_"},
 
-  if-verbose (coq.say "HB: postulate" Name "on" {coq.term->string T}),
+  if-verbose (coq.say {header} "postulate" Name "on" {coq.term->string T}),
 
   synthesis.infer-all-gref-deps Ps T M Ty,
   std.assert-ok! (coq.typecheck Ty _) "postulate-mixin: Ty illtyped",

--- a/HB/export.elpi
+++ b/HB/export.elpi
@@ -29,7 +29,7 @@ pred export.reexport-all-modules-and-CS i:option string.
 export.reexport-all-modules-and-CS Filter :- std.do! [
   coq.env.current-library File,
   export.private.compute-filter Filter MFilter,
-  if-verbose (coq.say "HB: exporting under the module path" MFilter),
+  if-verbose (coq.say {header} "exporting under the module path" MFilter),
 
   % NODE: std.list-uniq is for coq < 8.13
 
@@ -38,7 +38,7 @@ export.reexport-all-modules-and-CS Filter :- std.do! [
   std.map ModsCLFiltered module-to-export_module-nice NiceMods,
   std.map ModsCLFiltered module-to-export_module Mods,
 
-  if-verbose (coq.say "HB: exporting modules" NiceMods),
+  if-verbose (coq.say {header} "exporting modules" NiceMods),
   std.forall2 NiceMods Mods log.coq.env.export-module,
 
 
@@ -46,7 +46,7 @@ export.reexport-all-modules-and-CS Filter :- std.do! [
   std.filter {std.list-uniq InstCL} (export.private.instance-in-module MFilter) InstCLFiltered,
   std.map InstCLFiltered instance-to-export_instance Insts,
 
-  if-verbose (coq.say "HB: exporting CS instances" Insts),
+  if-verbose (coq.say {header} "exporting CS instances" Insts),
   std.forall Insts log.coq.CS.declare-instance,
 
   std.findall (abbrev-to-export File NiceAbbrev_ GR_) InstAbbL,
@@ -54,7 +54,7 @@ export.reexport-all-modules-and-CS Filter :- std.do! [
   std.map InstAbbLFiltered abbrev-to-export_name AbbNames,
   std.map InstAbbLFiltered abbrev-to-export_body AbbBodies,
 
-  if-verbose (coq.say "HB: exporting Abbreviations" AbbNames),
+  if-verbose (coq.say {header} "exporting Abbreviations" AbbNames),
   std.forall2 AbbNames AbbBodies (n\b\@global! => log.coq.notation.add-abbreviation n 0 b ff _),
 
 ].

--- a/HB/factory.elpi
+++ b/HB/factory.elpi
@@ -247,8 +247,8 @@ declare-mixin-or-factory MixinSrcClauses SectionCanonicalInstance
   build-deps-for-projections R MLwP GRDepsClausesProjs,
   GRDepsClauses = [gref-deps (indt R) MLwP, gref-deps (indc K) MLwP|GRDepsClausesProjs],
 
-  GRDepsClauses => mk-factory-sort MLwP (indt R) _ FactorySortCoe,
-  FactorySortCoe = coercion GRFSort _ _ _,
+  % GRDepsClauses => mk-factory-sort MLwP (indt R) _ FactorySortCoe,
+  % FactorySortCoe = coercion GRFSort _ _ _,
 
   % TODO: should this be in the Exports module?
 
@@ -273,17 +273,17 @@ declare-mixin-or-factory MixinSrcClauses SectionCanonicalInstance
     factory-nparams (indt R) NParams,
     factory-builder-nparams BuildConst NParams,
     phant-abbrev GRK (const BuildConst) BuildAbbrev,
-    gref-deps GRFSort MLwP,
-    factory-sort FactorySortCoe,
+    % gref-deps GRFSort MLwP,
+    % factory-sort FactorySortCoe,
   ]] NewClauses,
   std.forall NewClauses
     (c\ log.coq.env.accumulate current "hb.db" (clause _ _ c)),
 
   std.map {list-w-params_list MLwP} (_\ r\ r = maximal) Implicits,
   @global! => log.coq.arguments.set-implicit GRK [[maximal|Implicits]],
-  @global! => log.coq.coercion.declare FactorySortCoe,
+  % @global! => log.coq.coercion.declare FactorySortCoe,
 
-  NewClauses => instance.declare-factory-sort-deps (indt R),
+  % NewClauses => instance.declare-factory-sort-deps (indt R),
 
   log.coq.env.end-module-name "Exports" Exports,
   log.coq.env.end-module-name Module _,
@@ -329,8 +329,8 @@ declare-factory-alias MixinSrcClauses SectionCanonicalInstance
 
   GRDepsClauses => phant.of-gref ff GRK [] PhGRK0,
 
-  GRDepsClauses => mk-factory-sort MLwP (const C) _ FactorySortCoe,
-  FactorySortCoe = coercion GRFSort _ _ _,
+  % GRDepsClauses => mk-factory-sort MLwP (const C) _ FactorySortCoe,
+  % FactorySortCoe = coercion GRFSort _ _ _,
 
   if (mixin-first-class F _) (PhGRK = PhGRK0)
     (phant.append-fun-unify PhGRK0 PhGRK),
@@ -347,16 +347,16 @@ declare-factory-alias MixinSrcClauses SectionCanonicalInstance
       [ factory-nparams (const C) NParams,
         factory-constructor (const C) GRK,
         factory-builder-nparams BuildConst NParams,
-        gref-deps GRFSort MLwP,
-        factory-sort FactorySortCoe
+        % gref-deps GRFSort MLwP,
+        % factory-sort FactorySortCoe
       ]
     ] NewClauses,
 
   std.forall NewClauses (c\
     log.coq.env.accumulate current "hb.db" (clause _ _ c)),
-  @global! => log.coq.coercion.declare FactorySortCoe,
+  %@global! => log.coq.coercion.declare FactorySortCoe,
 
-  NewClauses => instance.declare-factory-sort-deps (const C),
+  % NewClauses => instance.declare-factory-sort-deps (const C),
 
   log.coq.env.end-module-name "Exports" Exports,
   log.coq.env.end-module-name Module _,

--- a/HB/factory.elpi
+++ b/HB/factory.elpi
@@ -247,8 +247,8 @@ declare-mixin-or-factory MixinSrcClauses SectionCanonicalInstance
   build-deps-for-projections R MLwP GRDepsClausesProjs,
   GRDepsClauses = [gref-deps (indt R) MLwP, gref-deps (indc K) MLwP|GRDepsClausesProjs],
 
-  % GRDepsClauses => mk-factory-sort MLwP (indt R) _ FactorySortCoe,
-  % FactorySortCoe = coercion GRFSort _ _ _,
+  GRDepsClauses => mk-factory-sort MLwP (indt R) _ FactorySortCoe,
+  FactorySortCoe = coercion GRFSort _ _ _,
 
   % TODO: should this be in the Exports module?
 
@@ -273,17 +273,17 @@ declare-mixin-or-factory MixinSrcClauses SectionCanonicalInstance
     factory-nparams (indt R) NParams,
     factory-builder-nparams BuildConst NParams,
     phant-abbrev GRK (const BuildConst) BuildAbbrev,
-    % gref-deps GRFSort MLwP,
-    % factory-sort FactorySortCoe,
+    gref-deps GRFSort MLwP,
+    factory-sort FactorySortCoe,
   ]] NewClauses,
   std.forall NewClauses
     (c\ log.coq.env.accumulate current "hb.db" (clause _ _ c)),
 
   std.map {list-w-params_list MLwP} (_\ r\ r = maximal) Implicits,
   @global! => log.coq.arguments.set-implicit GRK [[maximal|Implicits]],
-  % @global! => log.coq.coercion.declare FactorySortCoe,
+  @global! => log.coq.coercion.declare FactorySortCoe,
 
-  % NewClauses => instance.declare-factory-sort-deps (indt R),
+  NewClauses => instance.declare-factory-sort-deps (indt R),
 
   log.coq.env.end-module-name "Exports" Exports,
   log.coq.env.end-module-name Module _,
@@ -329,8 +329,8 @@ declare-factory-alias MixinSrcClauses SectionCanonicalInstance
 
   GRDepsClauses => phant.of-gref ff GRK [] PhGRK0,
 
-  % GRDepsClauses => mk-factory-sort MLwP (const C) _ FactorySortCoe,
-  % FactorySortCoe = coercion GRFSort _ _ _,
+  GRDepsClauses => mk-factory-sort MLwP (const C) _ FactorySortCoe,
+  FactorySortCoe = coercion GRFSort _ _ _,
 
   if (mixin-first-class F _) (PhGRK = PhGRK0)
     (phant.append-fun-unify PhGRK0 PhGRK),
@@ -347,16 +347,16 @@ declare-factory-alias MixinSrcClauses SectionCanonicalInstance
       [ factory-nparams (const C) NParams,
         factory-constructor (const C) GRK,
         factory-builder-nparams BuildConst NParams,
-        % gref-deps GRFSort MLwP,
-        % factory-sort FactorySortCoe
+        gref-deps GRFSort MLwP,
+        factory-sort FactorySortCoe
       ]
     ] NewClauses,
 
   std.forall NewClauses (c\
     log.coq.env.accumulate current "hb.db" (clause _ _ c)),
-  %@global! => log.coq.coercion.declare FactorySortCoe,
+  @global! => log.coq.coercion.declare FactorySortCoe,
 
-  % NewClauses => instance.declare-factory-sort-deps (const C),
+  NewClauses => instance.declare-factory-sort-deps (const C),
 
   log.coq.env.end-module-name "Exports" Exports,
   log.coq.env.end-module-name Module _,

--- a/HB/factory.elpi
+++ b/HB/factory.elpi
@@ -373,7 +373,7 @@ declare-factory-alias MixinSrcClauses SectionCanonicalInstance
 % deps of the record plus the record itself)
 pred build-deps-for-projections i:inductive, i:mixins, o:list prop.
 build-deps-for-projections R MLwP CL :- std.do! [
-  compat.map-filter {coq.CS.canonical-projections R} (x\y\x = some y) MixinOps,
+  compat.map-filter {coq.env.projections R} (x\y\x = some y) MixinOps,
   list-w-params.rcons MLwP (pl\t\r\ r = triple (indt R) pl t) MLRwP,
   std.map MixinOps (gr\r\ r = gref-deps (const gr) MLRwP) CL,
 ].

--- a/HB/factory.elpi
+++ b/HB/factory.elpi
@@ -33,9 +33,9 @@ argument->w-mixins (const-decl Id none Decl) (pr MLwP ArgwP) :- !, std.do! [
 ].
 argument->w-mixins (const-decl Id (some Body) Decl as CDecl)
     (pr MLwP ArgwP) :- !, std.do! [
-  if-verbose (coq.say "HB: arguments->w-mixins on const-decl Decl=" CDecl),
+  if-verbose (coq.say {header} "arguments->w-mixins on const-decl Decl=" CDecl),
   pdecl->w-mixins Decl (pr MLwP DeclwP),
-  if-verbose (coq.say "HB: arguments->w-mixins on const-decl Decl=" Decl
+  if-verbose (coq.say {header} "arguments->w-mixins on const-decl Decl=" Decl
     "\nwith MLwP =" MLwP),
   std.length {list-w-params_list MLwP} NML,
   if-verbose (coq.say "ML length =" NML),
@@ -114,7 +114,7 @@ pred mixin-decl-w-mixins i:string, i:string, i:term, i:(term -> A),
   i:(A -> pair (list (w-args mixinname)) A -> prop),
   o:pair (list (w-args mixinname)) A.
 mixin-decl-w-mixins DeclKind ID TySkel Rest Conv Out :- std.do! [
-  if-verbose (coq.say "HB: processing mixin" DeclKind ID),
+  if-verbose (coq.say {header} "processing mixin" DeclKind ID),
   std.assert! (not (var TySkel)) "HB: no type provided for mixin",
   purge-id TySkel TySkelNoId,
   std.assert-ok! (coq.elaborate-ty-skeleton TySkelNoId _ Ty)
@@ -130,7 +130,7 @@ pred key-decl-w-mixins i:string, i:string, i:term, i:(term -> A),
   i:(A -> pair (list (w-args mixinname)) A -> prop),
   o:pair mixins (w-params A).
 key-decl-w-mixins DeclKind ID TySkel Rest Conv Out :- std.do! [
-  if-verbose (coq.say "HB: processing key" DeclKind),
+  if-verbose (coq.say {header} "processing key" DeclKind),
   std.assert-ok! (coq.elaborate-ty-skeleton TySkel _ Ty) "key illtyped",
   coq.string->name ID N, @pi-decl N Ty t\ Conv (Rest t) (pr (MLwA t) (R t)),
   if (var Ty) (fresh-type Ty) true,
@@ -139,7 +139,7 @@ key-decl-w-mixins DeclKind ID TySkel Rest Conv Out :- std.do! [
 pred param-decl-w-mixins i:string, i:string, i:term, i:(term -> A),
   i:(A -> pair mixins (w-params A) -> prop), o:pair mixins (w-params A).
 param-decl-w-mixins DeclKind ID TySkel Rest Conv Out :- std.do! [
-  if-verbose (coq.say "HB: processing param" DeclKind),
+  if-verbose (coq.say {header} "processing param" DeclKind),
   std.assert-ok! (coq.elaborate-ty-skeleton TySkel _ Ty) "param illtyped",
   coq.string->name ID N, @pi-decl N Ty p\ Conv (Rest p) (pr (MLwP p) (R p)),
   if (var Ty) (fresh-type Ty) true,
@@ -191,27 +191,27 @@ mk-factory-abbrev Str GR Aliases FactAbbrev :- !, std.do! [
 pred declare-asset i:argument, i:asset.
 declare-asset Arg AssetKind :- std.do! [
   argument-name Arg Module,
-  if-verbose (coq.say "HB: start module and section" Module),
+  if-verbose (coq.say {header} "start module and section" Module),
   log.coq.env.begin-module Module none,
   log.coq.env.begin-section Module,
 
-  if-verbose (coq.say "HB: converting arguments" Arg "to factories"),
+  if-verbose (coq.say {header} "converting arguments" Arg "to factories"),
   argument->w-mixins Arg (pr FLwP ArgwP),
 
-  if-verbose (coq.say "HB: converting factories" FLwP "to mixins"),
+  if-verbose (coq.say {header} "converting factories" FLwP "to mixins"),
   factories-provide FLwP MLwP,
 
-  if-verbose (coq.say "HB: declaring context" FLwP),
+  if-verbose (coq.say {header} "declaring context" FLwP),
   context.declare FLwP Params TheKey MixinSrcClauses SectionCanonicalInstance,
 
   if (Arg = indt-decl _) (
     apply-w-params ArgwP Params TheKey (indt-decl (record _ Sort _ Fields)),
-    if-verbose (coq.say "HB: declare mixin or factory"),
+    if-verbose (coq.say {header} "declare mixin or factory"),
     declare-mixin-or-factory MixinSrcClauses SectionCanonicalInstance
       Params TheKey Sort Fields MLwP Module AssetKind
   ) (
     apply-w-params ArgwP Params TheKey (const-decl _ (some Sort) _),
-    if-verbose (coq.say "HB: declare factory alias"),
+    if-verbose (coq.say {header} "declare factory alias"),
     declare-factory-alias MixinSrcClauses SectionCanonicalInstance
       Params TheKey Sort MLwP Module
   )
@@ -222,7 +222,7 @@ pred declare-mixin-or-factory i:list prop, i:list constant, i:list term, i:term,
 declare-mixin-or-factory MixinSrcClauses SectionCanonicalInstance
     TheParams TheType Sort1 Fields GRFSwP Module D :- std.do! [
 
-  if-verbose (coq.say "HB: declare record axioms_:" Sort1),
+  if-verbose (coq.say {header} "declare record axioms_:" Sort1),
   Kname = "Axioms_",
   RDeclSkel = record "axioms_" Sort1 Kname Fields,
   std.assert-ok! (coq.elaborate-indt-decl-skeleton RDeclSkel RDecl) "record declaration illtyped",
@@ -252,12 +252,12 @@ declare-mixin-or-factory MixinSrcClauses SectionCanonicalInstance
 
   % TODO: should this be in the Exports module?
 
-  if-verbose (coq.say "HB: declare notation Build"),
+  if-verbose (coq.say {header} "declare notation Build"),
 
   GRDepsClauses => phant.of-gref ff GRK [] PhGRK,
   GRDepsClauses => phant.add-abbreviation "Build" PhGRK BuildConst BuildAbbrev,
 
-  if-verbose (coq.say "HB: declare notation axioms"),
+  if-verbose (coq.say {header} "declare notation axioms"),
 
   if (D = asset-mixin)
      (GRDepsClauses => mk-factory-abbrev "axioms" (indt R) FRClauses FactAbbrev,
@@ -265,7 +265,7 @@ declare-mixin-or-factory MixinSrcClauses SectionCanonicalInstance
       Clauses = [IdBuilderClause|FRClauses])
      (GRDepsClauses => mk-factory-abbrev "axioms" (indt R) Clauses FactAbbrev),
 
-  if-verbose (coq.say "HB: start module Exports"),
+  if-verbose (coq.say {header} "start module Exports"),
 
   log.coq.env.begin-module "Exports" none,
   std.flatten [Clauses, GRDepsClauses, [
@@ -288,7 +288,7 @@ declare-mixin-or-factory MixinSrcClauses SectionCanonicalInstance
   log.coq.env.end-module-name "Exports" Exports,
   log.coq.env.end-module-name Module _,
 
-  if-verbose (coq.say "HB: end modules and sections; export" Exports),
+  if-verbose (coq.say {header} "end modules and sections; export" Exports),
 
   export.module {calc (Module ^ ".Exports")} Exports,
 
@@ -301,7 +301,7 @@ pred declare-factory-alias  i:list prop, i:list constant, i:list term, i:term,
 declare-factory-alias MixinSrcClauses SectionCanonicalInstance
     TheParams TheType Ty1Skel GRFSwP Module :- std.do! [
 
-  if-verbose (coq.say "HB: declare constant axioms_:" Ty1Skel),
+  if-verbose (coq.say {header} "declare constant axioms_:" Ty1Skel),
   std.assert-ok! (coq.elaborate-ty-skeleton Ty1Skel _ Ty1) "Illtyped alias factory",
 
   abstract-over-section TheParams TheType MixinSrcClauses SectionCanonicalInstance coq.abstract-const-decl (pr Ty1 _) (pr Ty1Closed _) Section,
@@ -338,7 +338,7 @@ declare-factory-alias MixinSrcClauses SectionCanonicalInstance
 
   GRDepsClauses => mk-factory-abbrev "axioms" (const C) Clauses FactAbbrev,
 
-  if-verbose (coq.say "HB: start module Exports"),
+  if-verbose (coq.say {header} "start module Exports"),
 
   log.coq.env.begin-module "Exports" none,
 
@@ -361,7 +361,7 @@ declare-factory-alias MixinSrcClauses SectionCanonicalInstance
   log.coq.env.end-module-name "Exports" Exports,
   log.coq.env.end-module-name Module _,
 
-  if-verbose (coq.say "HB: end modules and sections; export" Exports),
+  if-verbose (coq.say {header} "end modules and sections; export" Exports),
 
   export.module {calc (Module ^ ".Exports")} Exports,
 
@@ -395,7 +395,7 @@ abstract-over-section TheParams TheType MixinSrcClauses SectionCanonicalInstance
 
 pred mk-factory-sort i:mixins, i:gref, o:gref, o:coercion.
 mk-factory-sort MLwP GR (const FactorySortCst) Coe :-
-  if-verbose (coq.say "HB: declaring tagged sort for GR=" GR),
+  if-verbose (coq.say {header} "declaring tagged sort for GR=" GR),
   synthesis.mixins-w-params.fun MLwP (mk-factory-sort.term GR) FactorySort,
   std.assert-ok! (coq.typecheck FactorySort FactorySortTy) "HB: cannot elaborate sort",
   log.coq.env.add-const-noimplicits "sort" FactorySort FactorySortTy ff FactorySortCst,

--- a/HB/instance.elpi
+++ b/HB/instance.elpi
@@ -56,7 +56,7 @@ declare-const Name BodySkel TyWPSkel CSL :- std.do! [
 
   % handle parameters via a section -- end
   if (TyWP = arity _) true (
-    if-verbose (coq.say "HB: closing instance section"),
+    if-verbose (coq.say {header} "closing instance section"),
     log.coq.env.end-section-name SectionName
   ),
 
@@ -77,13 +77,13 @@ declare-all T [class Class Struct MLwP|Rest] [pr Name CS|L] :-
 
   if (not(local-cs? T Struct))
      true % we build it
-     (if-verbose (coq.say "HB: skipping already existing"
+     (if-verbose (coq.say {header} "skipping already existing"
                     {nice-gref->string Struct} "instance on"
                     {coq.term->string T}),
       fail),
 
   if (synthesis.infer-all-args-let Params T KC KCApp ok)
-     (if-verbose (coq.say "HB: we can build a" {nice-gref->string Struct} "on"
+     (if-verbose (coq.say {header} "we can build a" {nice-gref->string Struct} "on"
         {coq.term->string T}))
      fail,
 
@@ -91,15 +91,17 @@ declare-all T [class Class Struct MLwP|Rest] [pr Name CS|L] :-
   coq.term->gref T TGR,
   Name is  {gref->modname-label TGR 1 "_"} ^ "__canonical__" ^ {gref->modname Struct 2 "_"},
 
-  if-verbose (coq.say "HB: declare canonical structure instance" Name),
+  if-verbose (coq.say {header} "declare canonical structure instance" Name),
 
   get-constructor Struct KS,
   private.optimize-class-body TGR {std.length Params} KCApp KCAppNames Clauses,
   coq.mk-app (global KS) {std.append Params [T, KCAppNames]} S,
+  if-verbose (coq.say {header} "structure instance for" Name "is" {coq.term->string S}),
   std.assert-ok! (coq.typecheck S STy) "declare-all: S illtyped",
 
   log.coq.env.add-const-noimplicits Name S STy @transparent! CS, % Bug coq/coq#11155, could be a Let
   with-locality (log.coq.CS.declare-instance CS), % Bug coq/coq#11155, should be local
+  if-verbose (coq.say {header} "structure instance" Name "declared"),
 
   Clauses => declare-all T Rest L.
 declare-all T [_|Rest] L :- declare-all T Rest L.
@@ -107,7 +109,7 @@ declare-all _ [] [].
 
 pred declare-factory-sort-deps i:gref.
 declare-factory-sort-deps  GR :- std.do! [
-  if-verbose (coq.say "HB: required instances on factory sort for" GR),
+  if-verbose (coq.say {header} "required instances on factory sort for" GR),
   Name is "SortInstances" ^ {std.any->string {new_int}},
   log.coq.env.begin-module Name none,
   log.coq.env.begin-section Name,
@@ -119,7 +121,7 @@ declare-factory-sort-deps  GR :- std.do! [
 
 pred declare-factory-sort-factory i:gref.
 declare-factory-sort-factory GR :- std.do! [
-  if-verbose (coq.say "HB: required instances on factory sort for" GR),
+  if-verbose (coq.say {header} "required instances on factory sort for" GR),
   Name is "SortInstances" ^ {std.any->string {new_int}},
   log.coq.env.begin-module Name none,
   log.coq.env.begin-section Name,
@@ -211,11 +213,11 @@ add-mixin T FGR MakeCanon MissingMixin [MixinSrcCl, BuilderDeclCl] CSL :- std.do
   % alias it.
   if (Bo = global (const C)) true
     (Name is {gref->modname FGR 2 "_"} ^"__to__" ^ {gref->modname MixinName 2 "_"},
-     if-verbose (coq.say "HB: declare mixin instance" Name),
+     if-verbose (coq.say {header} "declare mixin instance" Name),
      log.coq.env.add-const-noimplicits Name Bo Ty @transparent! C),
   if (MakeCanon = tt, whd (global (const C)) [] (global (indc _)) _)
      (std.do! [
-         if-verbose (coq.say "HB: declare canonical mixin instance" C),
+         if-verbose (coq.say {header} "declare canonical mixin instance" C),
          with-locality (log.coq.CS.declare-instance C),
          CSL = [pr "_" C]
      ]) (CSL = []),
@@ -238,7 +240,7 @@ add-all-mixins T FGR ML MakeCanon Clauses CSL :- std.do! [
 pred postulate-arity i:arity, i:list term, i:term, o:term, o:term.
 postulate-arity (parameter ID _ S A) Acc T T1 Ty :-
   std.assert-ok! (coq.typecheck-ty S _) "arity parameter illtyped",
-  if-verbose (coq.say "HB: postulating" ID),
+  if-verbose (coq.say {header} "postulating" ID),
   if (var S) (coq.fresh-type S) true,
   log.coq.env.add-section-variable-noimplicits ID S C,
   Var = global (const C),
@@ -302,7 +304,8 @@ optimize-body X X.
 
 pred optimize-class-body i:gref, i:int, i:term, o:term, o:list prop.
 optimize-class-body TGR NParams (let _ _ MBo R) R1 Clauses :- std.do! [
-  declare-mixin-name MBo (pr MC CL1),
+  (pi X Y\ copy (let _ _ X x\x) Y :- copy X Y) => copy MBo MBo1,
+  declare-mixin-name MBo1 MC CL1,
   if (TGR = indt _, MC = global (const C), not(coq.env.opaque? C))
      (log.coq.strategy.set [C] (level 1000)) true, % opaque stops simpl
   optimize-class-body TGR NParams (R MC) R1 CL2,
@@ -310,13 +313,22 @@ optimize-class-body TGR NParams (let _ _ MBo R) R1 Clauses :- std.do! [
 ].
 optimize-class-body _ _ (app L) (app L) [].
 
-pred declare-mixin-name i:term, o:(pair term (list prop)).
-declare-mixin-name (global GR) (pr (global GR) []).
-declare-mixin-name T (pr (global GR) []) :- mixin-mem T GR.
-declare-mixin-name T (pr T []) :- coq.safe-dest-app T (global GR) _, not (from _ _ GR).
-declare-mixin-name T (pr (global (const C)) [mixin-mem T (const C)]) :- std.do! [
-  if-verbose (coq.say "HB: declare-mixin-name" T),
+pred term-size i:term, i:int, o:int.
+term-size (app L) N M :- !, std.fold L N term-size M.
+term-size (fun _ T F) N M :- !,
+  (pi x\ term-size (F x) N M0),
+  term-size T M0 M1,
+  M is M1 + 1.
+term-size _ N M :- M is N + 1.
+
+pred declare-mixin-name i:term, o:term, o:list prop.
+%declare-mixin-name T T [] :- {term-size T 0} < 2, !.
+declare-mixin-name (global _ as T) T [].
+declare-mixin-name T (global GR) [] :- mixin-mem T GR.
+declare-mixin-name T T [] :- coq.safe-dest-app T (global GR) _, not (from _ _ GR).
+declare-mixin-name T (global (const C)) [mixin-mem T (const C)] :- std.do! [
   Name is "HB_unnamed_mixin_" ^ {std.any->string {new_int}},
+  if-verbose (coq.say {header} "Giving name" Name "to mixin instance" {coq.term->string T}),
   log.coq.env.add-const-noimplicits Name T _ @transparent! C,
 ].
 

--- a/HB/instance.elpi
+++ b/HB/instance.elpi
@@ -323,7 +323,7 @@ pred check-non-forgetful-inheritance i:term, i:gref.
 check-non-forgetful-inheritance _ _ :-
   get-option "non_forgetful_inheritance" tt, !.
 check-non-forgetful-inheritance T Factory :- std.do! [
-  if (coq.safe-dest-app T HdSym _, structure-key HdSym Super) (
+  if (coq.safe-dest-app T (global (const HdSym)) _, structure-key HdSym _ Super) (
     coq.warning "HB" "HB.non-forgetful-inheritance"
       "non forgetful inheritance detected.\n"
       "You have two solutions:"

--- a/HB/instance.elpi
+++ b/HB/instance.elpi
@@ -304,8 +304,7 @@ optimize-body X X.
 
 pred optimize-class-body i:gref, i:int, i:term, o:term, o:list prop.
 optimize-class-body TGR NParams (let _ _ MBo R) R1 Clauses :- std.do! [
-  (pi X Y\ copy (let _ _ X x\x) Y :- copy X Y) => copy MBo MBo1,
-  declare-mixin-name MBo1 MC CL1,
+  declare-mixin-name MBo MC CL1,
   if (TGR = indt _, MC = global (const C), not(coq.env.opaque? C))
      (log.coq.strategy.set [C] (level 1000)) true, % opaque stops simpl
   optimize-class-body TGR NParams (R MC) R1 CL2,

--- a/HB/instance.elpi
+++ b/HB/instance.elpi
@@ -194,7 +194,7 @@ declare-instance T F Clauses CSL :-
 % T built from factory F
 pred add-mixin i:term, i:factoryname, i:bool, i:mixinname,
   o:list prop, o:list (pair id constant).
-add-mixin T FGR MakeCanon MissingMixin [MixinSrcCl, BuilderDeclCl] CSL :-
+add-mixin T FGR MakeCanon MissingMixin [MixinSrcCl, BuilderDeclCl] CSL :- std.do! [
   new_int N, % timestamp
 
   synthesis.assert!-infer-mixin T MissingMixin Bo,
@@ -211,14 +211,15 @@ add-mixin T FGR MakeCanon MissingMixin [MixinSrcCl, BuilderDeclCl] CSL :-
   % alias it.
   if (Bo = global (const C)) true
     (Name is {gref->modname FGR 2 "_"} ^"__to__" ^ {gref->modname MixinName 2 "_"},
-     if-verbose (coq.say "HB: declare" Name),
+     if-verbose (coq.say "HB: declare mixin instance" Name),
      log.coq.env.add-const-noimplicits Name Bo Ty @transparent! C),
   if (MakeCanon = tt, whd (global (const C)) [] (global (indc _)) _)
-    (std.do! [
-        if-verbose (coq.say "HB: declare canonical mixin instance" C),
-        with-locality (log.coq.CS.declare-instance C),
-        CSL = [pr "_" C]
-    ]) (CSL = []).
+     (std.do! [
+         if-verbose (coq.say "HB: declare canonical mixin instance" C),
+         with-locality (log.coq.CS.declare-instance C),
+         CSL = [pr "_" C]
+     ]) (CSL = []),
+].
 
 pred add-all-mixins i:term, i:factoryname, i:list mixinname, i:bool,
   o:list prop, o:list (pair id constant).
@@ -302,7 +303,7 @@ optimize-body X X.
 pred optimize-class-body i:gref, i:int, i:term, o:term, o:list prop.
 optimize-class-body TGR NParams (let _ _ MBo R) R1 Clauses :- std.do! [
   declare-mixin-name MBo (pr MC CL1),
-  if (TGR = indt _, MC = global (const C), not(coq.env.const-opaque? C))
+  if (TGR = indt _, MC = global (const C), not(coq.env.opaque? C))
      (log.coq.strategy.set [C] (level 1000)) true, % opaque stops simpl
   optimize-class-body TGR NParams (R MC) R1 CL2,
   std.append CL1 CL2 Clauses,

--- a/HB/instance.elpi
+++ b/HB/instance.elpi
@@ -312,16 +312,7 @@ optimize-class-body TGR NParams (let _ _ MBo R) R1 Clauses :- std.do! [
 ].
 optimize-class-body _ _ (app L) (app L) [].
 
-pred term-size i:term, i:int, o:int.
-term-size (app L) N M :- !, std.fold L N term-size M.
-term-size (fun _ T F) N M :- !,
-  (pi x\ term-size (F x) N M0),
-  term-size T M0 M1,
-  M is M1 + 1.
-term-size _ N M :- M is N + 1.
-
 pred declare-mixin-name i:term, o:term, o:list prop.
-%declare-mixin-name T T [] :- {term-size T 0} < 2, !.
 declare-mixin-name (global _ as T) T [].
 declare-mixin-name T (global GR) [] :- mixin-mem T GR.
 declare-mixin-name T T [] :- coq.safe-dest-app T (global GR) _, not (from _ _ GR).

--- a/HB/instance.elpi
+++ b/HB/instance.elpi
@@ -82,7 +82,7 @@ declare-all T [class Class Struct MLwP|Rest] [pr Name CS|L] :-
                     {coq.term->string T}),
       fail),
 
-  if (synthesis.infer-all-args-let Params T KC KCApp)
+  if (synthesis.infer-all-args-let Params T KC KCApp ok)
      (if-verbose (coq.say "HB: we can build a" {nice-gref->string Struct} "on"
         {coq.term->string T}))
      fail,

--- a/HB/instance.elpi
+++ b/HB/instance.elpi
@@ -331,7 +331,7 @@ check-non-forgetful-inheritance T Factory :- std.do! [
       "1. (Best practice) Reorganize your hierarchy to make"
       {nice-gref->string Factory}
       "depend on"
-      { calc ({nice-gref->string (indt Super)} ^ ".") }
+      { calc ({nice-gref->string Super} ^ ".") }
       "See the paper \"Competing inheritance paths in"
       "dependent type theory\" (https://hal.inria.fr/hal-02463336) for more"
       "explanations"

--- a/HB/instance.elpi
+++ b/HB/instance.elpi
@@ -330,7 +330,7 @@ check-non-forgetful-inheritance T Factory :- std.do! [
       "1. (Best practice) Reorganize your hierarchy to make"
       {nice-gref->string Factory}
       "depend on"
-      { calc ({nice-gref->string Super} ^ ".") }
+      { calc ({nice-gref->string (indt Super)} ^ ".") }
       "See the paper \"Competing inheritance paths in"
       "dependent type theory\" (https://hal.inria.fr/hal-02463336) for more"
       "explanations"

--- a/HB/pack.elpi
+++ b/HB/pack.elpi
@@ -29,7 +29,7 @@ main Ty Args Instance :- std.do! [
         (AllFactories = Factories)
       (AllFactories = Factories, Tkey = T), % it's a factory, won't add anything
 
-  private.synth-instance ParamsSkel KC KS Tkey AllFactories Instance,
+  private.synth-instance ParamsSkel KC KS T Tkey AllFactories Instance,
 
 ].
 
@@ -39,19 +39,19 @@ main Ty Args Instance :- std.do! [
 
 namespace private {
 
-pred synth-instance i:list term, i:gref, i:gref, i:term, i:list term, o:term.
-synth-instance Params KC KS T [Factory|Factories] Instance :-
-  synthesis.under-new-mixin-src-from-factory.do! T Factory (_\
-    synth-instance Params KC KS T Factories Instance).
-synth-instance Params KC KS T [] Instance :- coq.safe-dest-app T (global _) _, !,
-  synthesis.under-local-canonical-mixins-of.do! T [
-    std.assert-ok! (synthesis.infer-all-args-let Params T KC ClassInstance) "HB.pack: cannot infer the instance",
-    std.append Params [T, ClassInstance] InstanceArgs,
+pred synth-instance i:list term, i:gref, i:gref, i:term, i:term, i:list term, o:term.
+synth-instance Params KC KS T Tkey [Factory|Factories] Instance :-
+  synthesis.under-new-mixin-src-from-factory.do! Tkey Factory (_\
+    synth-instance Params KC KS T Tkey Factories Instance).
+synth-instance Params KC KS T Tkey [] Instance :- coq.safe-dest-app Tkey (global _) _, !,
+  synthesis.under-local-canonical-mixins-of.do! Tkey [
+    std.assert-ok! (synthesis.infer-all-args-let Params Tkey KC ClassInstance) "HB.pack: cannot infer the instance",
+    std.append Params [T, {unwind {hd-beta-zeta ClassInstance []}}] InstanceArgs,
       Instance = app[global KS | InstanceArgs]
 ].
-synth-instance Params KC KS T [] Instance :- std.do! [
-  std.assert-ok! (synthesis.infer-all-args-let Params T KC ClassInstance) "HB.pack: cannot infer the instance",
-  std.append Params [T, ClassInstance] InstanceArgs,
+synth-instance Params KC KS T Tkey [] Instance :- std.do! [
+  std.assert-ok! (synthesis.infer-all-args-let Params Tkey KC ClassInstance) "HB.pack: cannot infer the instance",
+  std.append Params [T, {unwind {hd-beta-zeta ClassInstance []}}] InstanceArgs,
     Instance = app[global KS | InstanceArgs]
 ].
 

--- a/HB/pack.elpi
+++ b/HB/pack.elpi
@@ -6,13 +6,10 @@ namespace pack {
 
 pred main i:term, i:list argument, o:term.
 main Ty Args Instance :- std.do! [
-  std.assert! (coq.safe-dest-app Ty (global Structure) _) "HB.pack: not a structure",
-  std.assert! (class-def (class Class Structure MLwP)) "HB.pack: not a structure",
-  w-params.nparams MLwP NParams,
-  std.assert! ({std.length Args} > NParams) "HB.pack: not enough arguments",
-  std.split-at NParams Args ParamsSkelArgs [trm TSkel|FactoriesSkel],
-
-  std.assert! (std.map ParamsSkelArgs (x\r\x = trm r) ParamsSkel) "HB.pack: only terms are accepted",
+  std.assert! (not(var Ty)) "HB.pack: the structure to pack cannot be unknown, use HB.pack_for",
+  std.assert! (coq.safe-dest-app {unwind {whd Ty []}} (global Structure) Params) "HB.pack: not a structure",
+  std.assert! (class-def (class Class Structure _)) "HB.pack: not a structure",
+  std.assert! (Args = [trm TSkel|FactoriesSkel]) "HB.pack: not enough arguments",
 
   get-constructor Class KC,
   get-constructor Structure KS,
@@ -29,7 +26,7 @@ main Ty Args Instance :- std.do! [
         (AllFactories = Factories)
       (AllFactories = Factories, Tkey = T), % it's a factory, won't add anything
 
-  private.synth-instance ParamsSkel KC KS T Tkey AllFactories Instance,
+  private.synth-instance Params KC KS T Tkey AllFactories Instance,
 
 ].
 
@@ -59,14 +56,14 @@ pred elab-factories i:list argument, i:term, o:list term.
 elab-factories [] _ [].
 elab-factories [trm FactorySkel|More] T [Factory|Factories] :-
   std.assert-ok! (coq.elaborate-skeleton FactorySkel FTy MaybeFactory) "HB.pack: illtyped factory",
-  if2 (factory? FTy (triple _ _ T1)) % a factory
+  if2 (factory? {unwind {whd FTy []}} (triple _ _ T1)) % a factory
         (Factory = MaybeFactory)
-      (coq.safe-dest-app FTy (global GR) _, structure-key SortP ClassP GR) % a structure instance
+      (coq.safe-dest-app {unwind {whd FTy []}}  (global GR) _, structure-key SortP ClassP GR) % a structure instance
         (coq.mk-n-holes {structure-nparams GR} Params,
          std.append Params [MaybeFactory] ParamsF,
          coq.mk-app (global (const SortP)) ParamsF T1,
          coq.mk-app (global (const ClassP)) ParamsF Factory)
-      (coq.error "HB: argument" {coq.term->string Factory} "is not a factory, it has type:" {coq.term->string FTy}),
+      (coq.error "HB: argument" {coq.term->string MaybeFactory} "is not a factory, it has type:" {coq.term->string FTy}),
   std.assert-ok! (coq.unify-eq T T1) "HB.pack: factory for the wrong type",
   elab-factories More T Factories.
 

--- a/HB/pack.elpi
+++ b/HB/pack.elpi
@@ -27,9 +27,9 @@ main Ty Args Instance :- std.do! [
         (AllFactories = [app[global (const ClassProj)|ProjParams] | Factories], Tkey = T) % already existing class on T
       (def T _ _ Tkey) % we unfold letins if we can, they may hide constants with CS instances
         (AllFactories = Factories)
-      (AllFactories = Factories), % it's a factory, won't add anything
+      (AllFactories = Factories, Tkey = T), % it's a factory, won't add anything
 
-  private.synth-instance ParamsSkel KC KS T AllFactories Instance,
+  private.synth-instance ParamsSkel KC KS Tkey AllFactories Instance,
 
 ].
 

--- a/HB/pack.elpi
+++ b/HB/pack.elpi
@@ -23,9 +23,11 @@ main Ty Args Instance :- std.do! [
 
   if (var T) (coq.error "HB.pack: you must pass a type or at least one factory") true,
 
-  if (T = app[global (const SortProj)|ProjParams], structure-key SortProj ClassProj _)
-    (AllFactories = [app[global (const ClassProj)|ProjParams] | Factories]) % already existing class on T
-    (AllFactories = Factories), % it's a factory, won't add anything
+  if2 (T = app[global (const SortProj)|ProjParams], structure-key SortProj ClassProj _)
+        (AllFactories = [app[global (const ClassProj)|ProjParams] | Factories], Tkey = T) % already existing class on T
+      (def T _ _ Tkey) % we unfold letins if we can, they may hide constants with CS instances
+        (AllFactories = Factories)
+      (AllFactories = Factories), % it's a factory, won't add anything
 
   private.synth-instance ParamsSkel KC KS T AllFactories Instance,
 

--- a/HB/pack.elpi
+++ b/HB/pack.elpi
@@ -1,0 +1,66 @@
+
+/*        Hierarchy Builder: algebraic hierarchies made easy
+    This software is released under the terms of the MIT license              */
+
+namespace pack {
+
+pred main i:term, i:list argument, o:term.
+main Ty Args Instance :- std.do! [
+  std.assert! (coq.safe-dest-app Ty (global Structure) _) "HB.pack: not a structure",
+  std.assert! (class-def (class Class Structure MLwP)) "HB.pack: not a structure",
+  w-params.nparams MLwP NParams,
+  std.assert! ({std.length Args} > NParams) "HB.pack: not enough arguments",
+  std.split-at NParams Args ParamsSkelArgs [trm TSkel|FactoriesSkel],
+
+  std.assert! (std.map ParamsSkelArgs (x\r\x = trm r) ParamsSkel) "HB.pack: only terms are accepted",
+
+  get-constructor Class KC,
+  get-constructor Structure KS,
+
+  std.assert-ok! (coq.elaborate-ty-skeleton TSkel _ T) "HB.pack: not a type",
+
+  private.elab-factories FactoriesSkel T Factories,
+
+  if (var T) (coq.error "HB.pack: you must pass a type or at least one factory") true,
+
+  if (T = app[global (const SortProj)|ProjParams], structure-key SortProj ClassProj _)
+    (AllFactories = [app[global (const ClassProj)|ProjParams] | Factories]) % already existing class on T
+    (AllFactories = Factories), % it's a factory, won't add anything
+
+  private.synth-instance ParamsSkel KC KS T AllFactories Instance,
+
+].
+
+/* ------------------------------------------------------------------------- */
+/* ----------------------------- private code ------------------------------ */
+/* ------------------------------------------------------------------------- */
+
+namespace private {
+
+pred synth-instance i:list term, i:gref, i:gref, i:term, i:list term, o:term.
+synth-instance Params KC KS T [Factory|Factories] Instance :-
+  synthesis.under-new-mixin-src-from-factory.do! T Factory (_\
+    synth-instance Params KC KS T Factories Instance).
+synth-instance Params KC KS T [] Instance :- coq.safe-dest-app T (global _) _, !,
+  synthesis.under-local-canonical-mixins-of.do! T [
+    std.assert-ok! (synthesis.infer-all-args-let Params T KC ClassInstance) "HB.pack: cannot infer the instance",
+    std.append Params [T, ClassInstance] InstanceArgs,
+      Instance = app[global KS | InstanceArgs]
+].
+synth-instance Params KC KS T [] Instance :- std.do! [
+  std.assert-ok! (synthesis.infer-all-args-let Params T KC ClassInstance) "HB.pack: cannot infer the instance",
+  std.append Params [T, ClassInstance] InstanceArgs,
+    Instance = app[global KS | InstanceArgs]
+].
+
+pred elab-factories i:list argument, i:term, o:list term.
+elab-factories [] _ [].
+elab-factories [trm FactorySkel|More] T [Factory|Factories] :-
+  std.assert-ok! (coq.elaborate-skeleton FactorySkel FTy Factory) "HB.pack: illtyped factory",
+  if (factory? FTy (triple _ _ T1))
+     true
+     (coq.error "HB: argument" {coq.term->string Factory} "is not a factory, it has type:" {coq.term->string FTy}),
+  std.assert-ok! (coq.unify-eq T T1) "HB.pack: factory for the wrong type",
+  elab-factories More T Factories.
+
+}}

--- a/HB/pack.elpi
+++ b/HB/pack.elpi
@@ -58,10 +58,15 @@ synth-instance Params KC KS T Tkey [] Instance :- std.do! [
 pred elab-factories i:list argument, i:term, o:list term.
 elab-factories [] _ [].
 elab-factories [trm FactorySkel|More] T [Factory|Factories] :-
-  std.assert-ok! (coq.elaborate-skeleton FactorySkel FTy Factory) "HB.pack: illtyped factory",
-  if (factory? FTy (triple _ _ T1))
-     true
-     (coq.error "HB: argument" {coq.term->string Factory} "is not a factory, it has type:" {coq.term->string FTy}),
+  std.assert-ok! (coq.elaborate-skeleton FactorySkel FTy MaybeFactory) "HB.pack: illtyped factory",
+  if2 (factory? FTy (triple _ _ T1)) % a factory
+        (Factory = MaybeFactory)
+      (coq.safe-dest-app FTy (global GR) _, structure-key SortP ClassP GR) % a structure instance
+        (coq.mk-n-holes {structure-nparams GR} Params,
+         std.append Params [MaybeFactory] ParamsF,
+         coq.mk-app (global (const SortP)) ParamsF T1,
+         coq.mk-app (global (const ClassP)) ParamsF Factory)
+      (coq.error "HB: argument" {coq.term->string Factory} "is not a factory, it has type:" {coq.term->string FTy}),
   std.assert-ok! (coq.unify-eq T T1) "HB.pack: factory for the wrong type",
   elab-factories More T Factories.
 

--- a/HB/structure.elpi
+++ b/HB/structure.elpi
@@ -71,9 +71,9 @@ declare Module B :- std.do! [
     GRDepsClauses => MixinFirstClass => gref-deps GRPack MLwP =>
       phant.of-gref tt GRPack [] PhRepack),
   if-verbose (coq.say "HB: declaring pack abbreviation =" PhRepack),
-  phant.add-abbreviation "pack" PhRepack _ PackAbbrev,
+  %phant.add-abbreviation "pack" PhRepack _ PackAbbrev,
   
-  coq.notation.add-abbreviation-for-tactic [Module, "xpack"] "hb_instance" [trm (global Structure)],
+  coq.notation.add-abbreviation-for-tactic [Module, "pack"] "hb_instance" [trm (global Structure)],
 
   if-arg-sort (
     if-verbose (coq.say "HB: define arg_sort"),

--- a/HB/structure.elpi
+++ b/HB/structure.elpi
@@ -97,9 +97,11 @@ declare Module B :- std.do! [
 
   if (get-option "short.pack" ShortPack) (std.do! [
     if-verbose (coq.say "HB: short name for type:" ShortPack),
-    coq.notation.abbreviation-body PackAbbrev NPackAbbrev PackAbbrevTrm,
-    @global! => log.coq.notation.add-abbreviation
-      ShortPack NPackAbbrev PackAbbrevTrm ff _]) true,
+    % coq.notation.abbreviation-body PackAbbrev NPackAbbrev PackAbbrevTrm,
+    % @global! => log.coq.notation.add-abbreviation
+    %   ShortPack NPackAbbrev PackAbbrevTrm ff _]
+      coq.notation.add-abbreviation-for-tactic [ShortPack] "hb_instance" [trm (global Structure)]
+    ]) true,
 
   if-verbose (coq.say "HB: making coercion from type to target"),
   synthesis.infer-coercion-tgt MLwP CoeClass,

--- a/HB/structure.elpi
+++ b/HB/structure.elpi
@@ -36,7 +36,7 @@ declare Module B :- std.do! [
   log.coq.env.begin-module Module none,
 
   private.declare-class+structure MLwP
-    ClassName Structure SortProjection ClassProjection Factories,
+    ClassName Structure SortProjection ClassProjection Factories StructKeyClause,
 
   w-params.map MLwP (_\_\_\ mk-nil) NilwP,
   ClassAlias = (factory-alias->gref ClassName ClassName),
@@ -122,7 +122,7 @@ declare Module B :- std.do! [
   std.flatten [
       Factories, [ClassAlias], [is-structure Structure],
       NewJoins, [class-def CurrentClass], GRDepsClauses,
-      [gref-deps GRPack MLwP], [structure-key SortProjection Structure]
+      [gref-deps GRPack MLwP], [StructKeyClause]
     ]
     NewClauses,
   std.forall NewClauses (c\ log.coq.env.accumulate current "hb.db" (clause _ _ c)),
@@ -494,8 +494,8 @@ mk-class-field ClassName Params T _ (field [canonical ff] "class" (app [global C
   std.append Params [T] Args.
 
 % Builds the axioms record and the factories from this class to each mixin
-pred declare-class+structure i:mixins, o:factoryname, o:structure, o:term, o:term, o:list prop.
-declare-class+structure MLwP (indt ClassInd) (indt StructureInd) SortProjection ClassProjection AllFactories :- std.do! [
+pred declare-class+structure i:mixins, o:factoryname, o:structure, o:term, o:term, o:list prop, o:prop.
+declare-class+structure MLwP (indt ClassInd) (indt StructureInd) SortProjection ClassProjection AllFactories (structure-key SortP ClassP StructureInd):- std.do! [
 
   if-verbose (coq.say "HB: declare axioms record"MLwP ),
 

--- a/HB/structure.elpi
+++ b/HB/structure.elpi
@@ -73,7 +73,7 @@ declare Module B :- std.do! [
   if-verbose (coq.say "HB: declaring pack abbreviation =" PhRepack),
   phant.add-abbreviation "pack" PhRepack _ PackAbbrev,
   
-  coq.notation.add-abbreviation-for-tactic [Module, "xpack"] "hb_instance" [trm (global Structure)],
+  coq.notation.add-abbreviation-for-tactic [Module, "pack"] "hb_instance" [trm (global Structure)],
 
   if-arg-sort (
     if-verbose (coq.say "HB: define arg_sort"),
@@ -170,7 +170,7 @@ declare Module B :- std.do! [
     ]),
 
   std.flatten {std.map NewMixins mixin->factories} NewFactories,
-  NewClauses => std.forall NewFactories instance.declare-factory-sort-factory,
+  % NewClauses => std.forall NewFactories instance.declare-factory-sort-factory,
 
   log.coq.env.end-module-name "EtaAndMixinExports" EtaExports,
 

--- a/HB/structure.elpi
+++ b/HB/structure.elpi
@@ -66,15 +66,6 @@ declare Module B :- std.do! [
   log.coq.env.add-const-noimplicits "pack_" Pack _ @transparent! ConstPack,
   GRPack = const ConstPack,
 
-  if-verbose (coq.say "HB: declaring pack abbreviation"),
-  (ClassAlias => class-def CurrentClass =>
-    GRDepsClauses => MixinFirstClass => gref-deps GRPack MLwP =>
-      phant.of-gref tt GRPack [] PhRepack),
-  if-verbose (coq.say "HB: declaring pack abbreviation =" PhRepack),
-  phant.add-abbreviation "pack" PhRepack _ PackAbbrev,
-  
-  coq.notation.add-abbreviation-for-tactic [Module, "pack"] "hb_instance" [trm (global Structure)],
-
   if-arg-sort (
     if-verbose (coq.say "HB: define arg_sort"),
     std.assert-ok! (coq.typecheck SortProjection SortProjTy)
@@ -86,6 +77,16 @@ declare Module B :- std.do! [
 
   log.coq.env.begin-module "Exports" none,
 
+  %(ClassAlias => class-def CurrentClass =>
+  %  GRDepsClauses => MixinFirstClass => gref-deps GRPack MLwP =>
+  %    phant.of-gref tt GRPack [] PhRepack),
+  %if-verbose (coq.say "HB: declaring pack abbreviation =" PhRepack),
+  % phant.add-abbreviation "pack" PhRepack _ PackAbbrev,
+  
+  coq.mk-app (global Structure) {coq.mk-n-holes {w-params.nparams MLwP}} HB_Instance,
+
+  coq.notation.add-abbreviation-for-tactic [Module, "pack"] "hb_instance" [trm HB_Instance],
+
   if (get-option "short.type" ShortType) (
     if-verbose (coq.say "HB: short name for type:" ShortType),
     if (LocType = loc-abbreviation StrTypeAbbrev) (std.do! [
@@ -95,13 +96,17 @@ declare Module B :- std.do! [
     ]) (@global! => log.coq.notation.add-abbreviation
       ShortType 0 (global Structure) ff _)) true,
 
+  coq.mk-app (global Structure) {coq.mk-n-holes {w-params.nparams MLwP}} HB_Instance,
   if (get-option "short.pack" ShortPack) (std.do! [
     if-verbose (coq.say "HB: short name for type:" ShortPack),
     % coq.notation.abbreviation-body PackAbbrev NPackAbbrev PackAbbrevTrm,
     % @global! => log.coq.notation.add-abbreviation
     %  ShortPack NPackAbbrev PackAbbrevTrm ff _
-      coq.notation.add-abbreviation-for-tactic [ShortPack] "hb_instance" [trm (global Structure)]
-    ]) true,
+      coq.notation.add-abbreviation-for-tactic [ShortPack] "hb_instance" [trm HB_Instance]
+    ]) (std.do! [
+    if-verbose (coq.say "HB: declaring pack abbreviation"),
+    coq.notation.add-abbreviation-for-tactic [Module, "pack"] "hb_instance" [trm HB_Instance],
+    ]),
 
   if-verbose (coq.say "HB: making coercion from type to target"),
   synthesis.infer-coercion-tgt MLwP CoeClass,
@@ -169,7 +174,7 @@ declare Module B :- std.do! [
       instance.declare-const "_" EtaInstanceBody EtaInstanceArity _
     ]),
 
-  std.flatten {std.map NewMixins mixin->factories} NewFactories,
+  % std.flatten {std.map NewMixins mixin->factories} NewFactories,
   % NewClauses => std.forall NewFactories instance.declare-factory-sort-factory,
 
   log.coq.env.end-module-name "EtaAndMixinExports" EtaExports,

--- a/HB/structure.elpi
+++ b/HB/structure.elpi
@@ -73,7 +73,7 @@ declare Module B :- std.do! [
   if-verbose (coq.say "HB: declaring pack abbreviation =" PhRepack),
   phant.add-abbreviation "pack" PhRepack _ PackAbbrev,
   
-  @global! => log.coq.notation.add-abbreviation "xpack" 0 (global Structure) ff _,
+  coq.notation.add-abbreviation-for-tactic [Module, "xpack"] "hb_instance" [trm (global Structure)],
 
   if-arg-sort (
     if-verbose (coq.say "HB: define arg_sort"),

--- a/HB/structure.elpi
+++ b/HB/structure.elpi
@@ -99,7 +99,7 @@ declare Module B :- std.do! [
     if-verbose (coq.say "HB: short name for type:" ShortPack),
     % coq.notation.abbreviation-body PackAbbrev NPackAbbrev PackAbbrevTrm,
     % @global! => log.coq.notation.add-abbreviation
-    %   ShortPack NPackAbbrev PackAbbrevTrm ff _]
+    %  ShortPack NPackAbbrev PackAbbrevTrm ff _
       coq.notation.add-abbreviation-for-tactic [ShortPack] "hb_instance" [trm (global Structure)]
     ]) true,
 

--- a/HB/structure.elpi
+++ b/HB/structure.elpi
@@ -66,6 +66,13 @@ declare Module B :- std.do! [
   log.coq.env.add-const-noimplicits "pack_" Pack _ @transparent! ConstPack,
   GRPack = const ConstPack,
 
+  if-verbose (coq.say {header} "declaring pack abbreviation"),
+  (ClassAlias => class-def CurrentClass =>
+    GRDepsClauses => MixinFirstClass => gref-deps GRPack MLwP =>
+      phant.of-gref tt GRPack [] PhRepack),
+  if-verbose (coq.say {header} "declaring pack abbreviation =" PhRepack),
+  phant.add-abbreviation "pack" PhRepack _ PackAbbrev,
+
   if-arg-sort (
     if-verbose (coq.say {header} "define arg_sort"),
     std.assert-ok! (coq.typecheck SortProjection SortProjTy)
@@ -76,12 +83,6 @@ declare Module B :- std.do! [
   if-verbose (coq.say {header} "start module Exports"),
 
   log.coq.env.begin-module "Exports" none,
-
-  %(ClassAlias => class-def CurrentClass =>
-  %  GRDepsClauses => MixinFirstClass => gref-deps GRPack MLwP =>
-  %    phant.of-gref tt GRPack [] PhRepack),
-  %if-verbose (coq.say {header} "declaring pack abbreviation =" PhRepack),
-  % phant.add-abbreviation "pack" PhRepack _ PackAbbrev,
   
   if (get-option "short.type" ShortType) (
     if-verbose (coq.say {header} "short name for type:" ShortType),
@@ -92,18 +93,12 @@ declare Module B :- std.do! [
     ]) (@global! => log.coq.notation.add-abbreviation
       ShortType 0 (global Structure) ff _)) true,
 
-  coq.mk-app (global Structure) {coq.mk-n-holes {w-params.nparams MLwP}} HB_Instance,
   if (get-option "short.pack" ShortPack) (std.do! [
     if-verbose (coq.say {header} "declaring pack abbreviation:" ShortPack),
-    % coq.notation.abbreviation-body PackAbbrev NPackAbbrev PackAbbrevTrm,
-    % @global! => log.coq.notation.add-abbreviation
-    %  ShortPack NPackAbbrev PackAbbrevTrm ff _
-      coq.notation.add-abbreviation-for-tactic ShortPack "HB.pack_for" [trm HB_Instance]
-    ]) (std.do! [
-    PackAbbrevName is Module ^ ".pack",
-    if-verbose (coq.say {header} "declaring pack abbreviation:" PackAbbrevName),
-    coq.notation.add-abbreviation-for-tactic PackAbbrevName "HB.pack_for" [trm HB_Instance],
-  ]),
+    coq.notation.abbreviation-body PackAbbrev NPackAbbrev PackAbbrevTrm,
+    @global! => log.coq.notation.add-abbreviation
+      ShortPack NPackAbbrev PackAbbrevTrm ff _
+    ]) true,
 
   if-verbose (coq.say {header} "making coercion from type to target"),
   synthesis.infer-coercion-tgt MLwP CoeClass,
@@ -172,8 +167,8 @@ declare Module B :- std.do! [
     ]
     ),
 
-  % std.flatten {std.map NewMixins mixin->factories} NewFactories,
-  % NewClauses => std.forall NewFactories instance.declare-factory-sort-factory,
+  std.flatten {std.map NewMixins mixin->factories} NewFactories,
+  NewClauses => std.forall NewFactories instance.declare-factory-sort-factory,
 
   log.coq.env.end-module-name "EtaAndMixinExports" EtaExports,
 

--- a/HB/structure.elpi
+++ b/HB/structure.elpi
@@ -31,7 +31,7 @@ declare Module B :- std.do! [
 
   % TODO: check we never define the superclass of an exising class
 
-  if-verbose (coq.say "HB: start module" Module),
+  if-verbose (coq.say {header} "start module" Module),
 
   log.coq.env.begin-module Module none,
 
@@ -48,43 +48,43 @@ declare Module B :- std.do! [
   std.map NewMixins (m\ r\ r = mixin-first-class m ClassName) MixinFirstClass,
 
 
-  if-verbose (coq.say "HB: structure: new mixins" NewMixins),
-  if-verbose (coq.say "HB: structure: mixin first class" MixinFirstClass),
+  if-verbose (coq.say {header} "structure: new mixins" NewMixins),
+  if-verbose (coq.say {header} "structure: mixin first class" MixinFirstClass),
 
 
   private.declare-auto-infer-params-abbrev Structure MLwP LocType,
 
-  if-verbose (coq.say "HB: declaring clone abbreviation"),
+  if-verbose (coq.say {header} "declaring clone abbreviation"),
   w-params.then MLwP phant.fun-real phant.fun-real
     (private.clone-phant-body ClassName SortProjection Structure) PhClone,
   phant.add-abbreviation "clone" PhClone _ _,
 
-  if-verbose (coq.say "HB: declaring pack_ constant"),
+  if-verbose (coq.say {header} "declaring pack_ constant"),
   (ClassAlias => class-def CurrentClass => GRDepsClauses =>
     w-params.then MLwP mk-fun mk-fun (private.pack-body ClassName) Pack),
-  if-verbose (coq.say "HB: declaring pack_ constant =" Pack),
+  if-verbose (coq.say {header} "declaring pack_ constant =" Pack),
   log.coq.env.add-const-noimplicits "pack_" Pack _ @transparent! ConstPack,
   GRPack = const ConstPack,
 
   if-arg-sort (
-    if-verbose (coq.say "HB: define arg_sort"),
+    if-verbose (coq.say {header} "define arg_sort"),
     std.assert-ok! (coq.typecheck SortProjection SortProjTy)
       "HB: BUG: cannot retype projection",
     log.coq.env.add-const-noimplicits "arg_sort" SortProjection SortProjTy ff ArgSortCst
   ),
 
-  if-verbose (coq.say "HB: start module Exports"),
+  if-verbose (coq.say {header} "start module Exports"),
 
   log.coq.env.begin-module "Exports" none,
 
   %(ClassAlias => class-def CurrentClass =>
   %  GRDepsClauses => MixinFirstClass => gref-deps GRPack MLwP =>
   %    phant.of-gref tt GRPack [] PhRepack),
-  %if-verbose (coq.say "HB: declaring pack abbreviation =" PhRepack),
+  %if-verbose (coq.say {header} "declaring pack abbreviation =" PhRepack),
   % phant.add-abbreviation "pack" PhRepack _ PackAbbrev,
   
   if (get-option "short.type" ShortType) (
-    if-verbose (coq.say "HB: short name for type:" ShortType),
+    if-verbose (coq.say {header} "short name for type:" ShortType),
     if (LocType = loc-abbreviation StrTypeAbbrev) (std.do! [
       coq.notation.abbreviation-body StrTypeAbbrev NStrTypeAbbrev StrTypeTm,
       @global! => log.coq.notation.add-abbreviation
@@ -94,37 +94,37 @@ declare Module B :- std.do! [
 
   coq.mk-app (global Structure) {coq.mk-n-holes {w-params.nparams MLwP}} HB_Instance,
   if (get-option "short.pack" ShortPack) (std.do! [
-    if-verbose (coq.say "HB: declaring pack abbreviation:" ShortPack),
+    if-verbose (coq.say {header} "declaring pack abbreviation:" ShortPack),
     % coq.notation.abbreviation-body PackAbbrev NPackAbbrev PackAbbrevTrm,
     % @global! => log.coq.notation.add-abbreviation
     %  ShortPack NPackAbbrev PackAbbrevTrm ff _
       coq.notation.add-abbreviation-for-tactic ShortPack "HB.pack_for" [trm HB_Instance]
     ]) (std.do! [
     PackAbbrevName is Module ^ ".pack",
-    if-verbose (coq.say "HB: declaring pack abbreviation:" PackAbbrevName),
+    if-verbose (coq.say {header} "declaring pack abbreviation:" PackAbbrevName),
     coq.notation.add-abbreviation-for-tactic PackAbbrevName "HB.pack_for" [trm HB_Instance],
     ]),
 
-  if-verbose (coq.say "HB: making coercion from type to target"),
+  if-verbose (coq.say {header} "making coercion from type to target"),
   synthesis.infer-coercion-tgt MLwP CoeClass,
   if-arg-sort (private.declare-sort-coercion CoeClass Structure
     (global (const ArgSortCst))),
   private.declare-sort-coercion CoeClass Structure SortProjection,
 
-  if-verbose (coq.say "HB: exporting unification hints"),
+  if-verbose (coq.say {header} "exporting unification hints"),
   ClassAlias => Factories => GRDepsClauses =>
     private.declare-unification-hints SortProjection ClassProjection CurrentClass NewJoins,
   % Register in Elpi's DB the new structure
   % NOT TODO: All these acc are correctly locaed in an Export Module
 
   if (ClassName = indt ClassInd) (std.do![
-    if-verbose (coq.say "HB: exporting coercions from class to mixins"),
+    if-verbose (coq.say {header} "exporting coercions from class to mixins"),
     std.forall {coq.env.projections ClassInd}
       (private.export-mixin-coercion ClassName)
     ])
     (coq.say "declare:" ClassName "should be an inductive", fail),
 
-  if-verbose (coq.say "HB: accumulating various props"),
+  if-verbose (coq.say {header} "accumulating various props"),
   std.flatten [
       Factories, [ClassAlias], [is-structure Structure],
       NewJoins, [class-def CurrentClass], GRDepsClauses,
@@ -134,25 +134,25 @@ declare Module B :- std.do! [
   std.forall NewClauses (c\ log.coq.env.accumulate current "hb.db" (clause _ _ c)),
 
 
-  if-verbose (coq.say "HB: stop module Exports"),
+  if-verbose (coq.say {header} "stop module Exports"),
   log.coq.env.end-module-name "Exports" Exports,
 
   log.coq.env.import-module "Exports" Exports,
 
-  if-verbose (coq.say "HB: declaring on_ abbreviation"),
+  if-verbose (coq.say {header} "declaring on_ abbreviation"),
 
   private.mk-infer-key CoeClass ClassProjection NilwP (global Structure) PhClass,
 
   phant.add-abbreviation "on_" PhClass _ ClassOfAbbrev,
   (pi c\ coq.notation.abbreviation ClassOfAbbrev [c] (ClassOfAbbrev_ c)),
 
-  if-verbose (coq.say "HB: declaring `copy` abbreviation"),
+  if-verbose (coq.say {header} "declaring `copy` abbreviation"),
 
   coq.mk-app (global ClassName) {params->holes NilwP} AppClassHoles,
   @global! => log.coq.notation.add-abbreviation "copy" 2
     {{fun T C => (lp:(ClassOfAbbrev_ C) : (lp:AppClassHoles T)) }} tt _,
 
-  if-verbose (coq.say "HB: declaring on abbreviation"),
+  if-verbose (coq.say {header} "declaring on abbreviation"),
 
   @global! => log.coq.notation.add-abbreviation "on" 1
     {{fun T => (lp:{{ ClassOfAbbrev_ {{_}} }} : (lp:AppClassHoles T)) }} tt
@@ -162,7 +162,7 @@ declare Module B :- std.do! [
 
   if (get-option "primitive" tt) true (
     true
-    % if-verbose (coq.say "HB: eta expanded instances"),
+    % if-verbose (coq.say {header} "eta expanded instances"),
     % NewClauses => std.do! [
     %   w-params.fold MLwP mk-fun
     %     (private.mk-hb-eta.on Structure SortProjection OnAbbrev) EtaInstanceBody,
@@ -180,21 +180,21 @@ declare Module B :- std.do! [
 
   log.coq.env.end-module-name Module ModulePath,
 
-  if-verbose (coq.say "HB: end modules; export" Exports),
+  if-verbose (coq.say {header} "end modules; export" Exports),
 
   export.module {calc (Module ^ ".Exports")} Exports,
 
-  if-verbose (coq.say "HB: export" EtaExports),
+  if-verbose (coq.say {header} "export" EtaExports),
 
   export.module {calc (Module ^ ".EtaAndMixinExports")} EtaExports,
 
-  if-verbose (coq.say "HB: exporting operations"),
+  if-verbose (coq.say {header} "exporting operations"),
     ClassAlias => Factories => GRDepsClauses =>
       private.export-operations Structure SortProjection ClassProjection MLwP [] EX MLToExport,
     % TODO: issue an Arguments op T : rename, where T is the name written by
     %   the user in Definition foo := { T of ... }
 
-  if-verbose (coq.say "HB: operations meta-data module: ElpiOperations"),
+  if-verbose (coq.say {header} "operations meta-data module: ElpiOperations"),
 
   ElpiOperationModName is "ElpiOperations" ^ {std.any->string {new_int}},
   log.coq.env.begin-module ElpiOperationModName none,
@@ -202,7 +202,7 @@ declare Module B :- std.do! [
   log.coq.env.end-module-name ElpiOperationModName ElpiOperations,
   export.module ElpiOperationModName ElpiOperations,
 
-  if-verbose (coq.say "HB: abbreviation factory-by-classname"),
+  if-verbose (coq.say {header} "abbreviation factory-by-classname"),
 
   NewClauses => factory.declare-abbrev Module (factory.by-classname ClassName),
 
@@ -267,7 +267,7 @@ export-1-operation M Struct Psort Pclass MwP (some Poperation) EXI EXO :- !, std
 
   w-params.then MwP mk-fun-prod ignore (operation-body-and-ty EXI Poperation Struct Psort Pclass) (pr Body BodyTy),
 
-  if-verbose (coq.say "HB: export operation" Name),
+  if-verbose (coq.say {header} "export operation" Name),
   log.coq.env.add-const-noimplicits Name Body BodyTy @transparent! C,
 
   w-params.nparams MwP NP,
@@ -361,14 +361,14 @@ declare-coercion SortProjection ClassProjection
   CName is ModNameF ^ "_class__to__" ^ ModNameT ^ "_class",
   SName is ModNameF ^ "__to__" ^ ModNameT,
 
-  if-verbose (coq.say "HB: declare coercion" SName),
+  if-verbose (coq.say {header} "declare coercion" SName),
 
   w-params.then FMLwP mk-fun mk-fun
     (mk-coe-class-body FC TC TMLwP) CoeBody,
 
   std.assert-ok! (coq.typecheck CoeBody Ty) "declare-coercion: CoeBody illtyped",
 
-  if-verbose (coq.say "HB: declare coercion hint" CName),
+  if-verbose (coq.say {header} "declare coercion hint" CName),
 
   log.coq.env.add-const-noimplicits CName CoeBody Ty @transparent! C,
   log.coq.coercion.declare (coercion (const C) 1 FC (grefclass TC)),
@@ -380,14 +380,14 @@ declare-coercion SortProjection ClassProjection
 
   std.assert-ok! (coq.typecheck SCoeBody STy) "declare-coercion: SCoeBody illtyped",
 
-  if-verbose (coq.say "HB: declare unification hint" SName),
+  if-verbose (coq.say {header} "declare unification hint" SName),
 
   log.coq.env.add-const-noimplicits SName SCoeBody STy @transparent! SC,
   log.coq.coercion.declare (coercion (const SC) 0 StructureF (grefclass StructureT)),
 
   log.coq.CS.declare-instance SC,
 
-  if-verbose (coq.say "HB: declare coercion path compression rules"),
+  if-verbose (coq.say {header} "declare coercion path compression rules"),
 
   findall-classes All,
   CurrentTgtClass = (class TC StructureT TMLwP),
@@ -452,7 +452,7 @@ declare-join (class C3 S3 MLwP3) (pr (class C1 S1 _) (class C2 S2 _)) (join C1 C
   factory-nparams C1 N1,
   factory-nparams C2 N2,
 
-  if-verbose (coq.say "HB: declare unification hint" Name),
+  if-verbose (coq.say {header} "declare unification hint" Name),
   w-params.fold MLwP3 mk-fun (join-body N1 N2 S3
     (global S2_Pack) S1_sort S3_to_S1 S2_class S3_to_S2) JoinBody,
   std.assert-ok! (coq.typecheck JoinBody Ty) "declare-join: JoinBody illtyped",
@@ -484,7 +484,7 @@ pred synthesize-fields i:term, i:list (w-args mixinname), o:record-decl.
 synthesize-fields _T []     end-record.
 synthesize-fields T  [triple M Args _|ML] (field _ Name MTy Fields) :- std.do! [
   Name is {gref->modname M 2 "_"} ^ "_mixin",
-  if-verbose (coq.say "HB: typing class field" M),
+  if-verbose (coq.say {header} "typing class field" M),
   std.assert! (synthesis.infer-all-gref-deps Args T M MTy) "anomaly: a field type cannot be solved",
   @pi-decl `m` MTy m\ mixin-src T M m => synthesize-fields T ML (Fields m)
 ].
@@ -505,7 +505,7 @@ mk-class-field ClassName Params T _ (field [canonical ff] "class" (app [global C
 pred declare-class+structure i:mixins, o:factoryname, o:structure, o:term, o:term, o:list prop, o:prop.
 declare-class+structure MLwP (indt ClassInd) (indt StructureInd) SortProjection ClassProjection AllFactories (structure-key SortP ClassP (indt StructureInd)):- std.do! [
 
-  if-verbose (coq.say "HB: declare axioms record"MLwP ),
+  if-verbose (coq.say {header} "declare axioms record"MLwP ),
 
   w-params.then MLwP (mk-parameter explicit) (mk-parameter explicit)
     synthesize-fields.body ClassDeclaration,
@@ -523,7 +523,7 @@ declare-class+structure MLwP (indt ClassInd) (indt StructureInd) SortProjection 
     r = from (indt ClassInd) m (const P)) Factories,
   AllFactories = [factory-nparams (indt ClassInd) NParams | Factories],
 
-  if-verbose (coq.say "HB: declare type record"),
+  if-verbose (coq.say {header} "declare type record"),
 
   w-params.then MLwP (mk-parameter explicit) mk-record+sort-field
     (mk-class-field (indt ClassInd)) StructureDeclaration,
@@ -542,7 +542,7 @@ declare-class+structure MLwP (indt ClassInd) (indt StructureInd) SortProjection 
 pred declare-sort-coercion i:class, i:structure, i:term.
 declare-sort-coercion CoeClass StructureName (global Proj) :-
 
-  if-verbose (coq.say "HB: declare sort coercion"),
+  if-verbose (coq.say {header} "declare sort coercion"),
 
   log.coq.coercion.declare (coercion Proj 0 StructureName CoeClass).
 
@@ -559,7 +559,7 @@ export-mixin-coercion _ none.
 export-mixin-coercion ClassName (some C) :-
   coq.env.typeof (const C) CTy,
   coq.prod-tgt->gref CTy MixinGR,
-  if-verbose (coq.say "HB: export class to mixin coercion for mixin" {nice-gref->string MixinGR}),
+  if-verbose (coq.say {header} "export class to mixin coercion for mixin" {nice-gref->string MixinGR}),
   log.coq.coercion.declare (coercion (const C) _ ClassName (grefclass MixinGR)).
 
 pred mc-compat-structure i:string, i:modpath, i:list mixinname, i:int, i:term, i:gref, i:option gref.

--- a/HB/structure.elpi
+++ b/HB/structure.elpi
@@ -501,7 +501,7 @@ mk-class-field ClassName Params T _ (field [canonical ff] "class" (app [global C
 
 % Builds the axioms record and the factories from this class to each mixin
 pred declare-class+structure i:mixins, o:factoryname, o:structure, o:term, o:term, o:list prop, o:prop.
-declare-class+structure MLwP (indt ClassInd) (indt StructureInd) SortProjection ClassProjection AllFactories (structure-key SortP ClassP StructureInd):- std.do! [
+declare-class+structure MLwP (indt ClassInd) (indt StructureInd) SortProjection ClassProjection AllFactories (structure-key SortP ClassP (indt StructureInd)):- std.do! [
 
   if-verbose (coq.say "HB: declare axioms record"MLwP ),
 

--- a/HB/structure.elpi
+++ b/HB/structure.elpi
@@ -156,20 +156,22 @@ declare Module B :- std.do! [
 
   @global! => log.coq.notation.add-abbreviation "on" 1
     {{fun T => (lp:{{ ClassOfAbbrev_ {{_}} }} : (lp:AppClassHoles T)) }} tt
-    OnAbbrev,
+    _OnAbbrev,
 
   log.coq.env.begin-module "EtaAndMixinExports" none,
 
   if (get-option "primitive" tt) true (
-    if-verbose (coq.say "HB: eta expanded instances"),
-    NewClauses => std.do! [
-      w-params.fold MLwP mk-fun
-        (private.mk-hb-eta.on Structure SortProjection OnAbbrev) EtaInstanceBody,
-      w-params.fold MLwP (mk-parameter explicit)
-        (private.mk-hb-eta.arity Structure ClassName SortProjection)
-        EtaInstanceArity,
-      instance.declare-const "_" EtaInstanceBody EtaInstanceArity _
-    ]),
+    true
+    % if-verbose (coq.say "HB: eta expanded instances"),
+    % NewClauses => std.do! [
+    %   w-params.fold MLwP mk-fun
+    %     (private.mk-hb-eta.on Structure SortProjection OnAbbrev) EtaInstanceBody,
+    %   w-params.fold MLwP (mk-parameter explicit)
+    %     (private.mk-hb-eta.arity Structure ClassName SortProjection)
+    %     EtaInstanceArity,
+    %   instance.declare-const "_" EtaInstanceBody EtaInstanceArity _
+    % ]
+    ),
 
   % std.flatten {std.map NewMixins mixin->factories} NewFactories,
   % NewClauses => std.forall NewFactories instance.declare-factory-sort-factory,
@@ -700,32 +702,32 @@ sigT->list-w-params {{ lib:@hb.sigT _ lp:{{ fun N Ty B }} }} L C :-
   @pi-decl N Ty t\
     product->triples (B t) (Rest t) C.
 
-pred mk-hb-eta.on i:structure, i:term, i:abbreviation,
-  i:list term, i:name, i:term, i:A, o:term.
-mk-hb-eta.on Structure SortProjection OnAbbrev
-    Params NT _T _ (fun NT Ty Body) :- !, std.do! [
-  coq.mk-app (global Structure) Params Ty,
-  @pi-decl NT Ty s\ sigma Tm\ std.do! [
-    coq.mk-app {{lib:@hb.eta}}
-      [_, {coq.mk-app SortProjection {std.append Params [s]}}]
-      Tm,
-    std.assert-ok! (coq.typecheck Tm _) "HB: eta illtyped",
-    coq.notation.abbreviation OnAbbrev [Tm] (Body s)
-  ]
-].
-
-pred mk-hb-eta.arity i:structure, i:classname, i:term, i:list term,
-  i:name, i:term, i:A, o:arity.
-mk-hb-eta.arity Structure ClassName SortProjection
-    Params NT _T _ Out :- !, std.do! [
-  coq.mk-app (global Structure) Params Ty,
-  (@pi-decl NT Ty s\ sigma Tm\ std.do! [
-    coq.mk-app {{lib:@hb.eta}}
-      [_, {coq.mk-app SortProjection {std.append Params [s]}}] Tm,
-    std.assert-ok! (coq.typecheck Tm _) "HB: eta illtyped",
-    coq.mk-app (global ClassName) {std.append Params [Tm]} (Concl s)
-  ]),
-  Out = parameter {coq.name->id NT} explicit Ty s\ arity (Concl s)
-].
-
+% pred mk-hb-eta.on i:structure, i:term, i:abbreviation,
+%   i:list term, i:name, i:term, i:A, o:term.
+% mk-hb-eta.on Structure SortProjection OnAbbrev
+%     Params NT _T _ (fun NT Ty Body) :- !, std.do! [
+%   coq.mk-app (global Structure) Params Ty,
+%   @pi-decl NT Ty s\ sigma Tm\ std.do! [
+%     coq.mk-app {{lib:@hb.eta}}
+%       [_, {coq.mk-app SortProjection {std.append Params [s]}}]
+%       Tm,
+%     std.assert-ok! (coq.typecheck Tm _) "HB: eta illtyped",
+%     coq.notation.abbreviation OnAbbrev [Tm] (Body s)
+%   ]
+% ].
+% 
+% pred mk-hb-eta.arity i:structure, i:classname, i:term, i:list term,
+%   i:name, i:term, i:A, o:arity.
+% mk-hb-eta.arity Structure ClassName SortProjection
+%     Params NT _T _ Out :- !, std.do! [
+%   coq.mk-app (global Structure) Params Ty,
+%   (@pi-decl NT Ty s\ sigma Tm\ std.do! [
+%     coq.mk-app {{lib:@hb.eta}}
+%       [_, {coq.mk-app SortProjection {std.append Params [s]}}] Tm,
+%     std.assert-ok! (coq.typecheck Tm _) "HB: eta illtyped",
+%     coq.mk-app (global ClassName) {std.append Params [Tm]} (Concl s)
+%   ]),
+%   Out = parameter {coq.name->id NT} explicit Ty s\ arity (Concl s)
+% ].
+% 
 }}

--- a/HB/structure.elpi
+++ b/HB/structure.elpi
@@ -52,7 +52,7 @@ declare Module B :- std.do! [
   if-verbose (coq.say {header} "structure: mixin first class" MixinFirstClass),
 
 
-  private.declare-auto-infer-params-abbrev Structure MLwP LocType,
+  private.declare-auto-infer-params-abbrev Structure MLwP LocType PHClauses,
 
   if-verbose (coq.say {header} "declaring clone abbreviation"),
   w-params.then MLwP phant.fun-real phant.fun-real
@@ -99,11 +99,12 @@ declare Module B :- std.do! [
     % @global! => log.coq.notation.add-abbreviation
     %  ShortPack NPackAbbrev PackAbbrevTrm ff _
       coq.notation.add-abbreviation-for-tactic ShortPack "HB.pack_for" [trm HB_Instance]
-    ]) (std.do! [
-    PackAbbrevName is Module ^ ".pack",
-    if-verbose (coq.say {header} "declaring pack abbreviation:" PackAbbrevName),
-    coq.notation.add-abbreviation-for-tactic PackAbbrevName "HB.pack_for" [trm HB_Instance],
-  ]),
+    ]) true,
+  %  (std.do! [
+  %  PackAbbrevName is Module ^ ".pack",
+  %  if-verbose (coq.say {header} "declaring pack abbreviation:" PackAbbrevName),
+  %  coq.notation.add-abbreviation-for-tactic PackAbbrevName "HB.pack_for" [trm HB_Instance],
+  %]),
 
   if-verbose (coq.say {header} "making coercion from type to target"),
   synthesis.infer-coercion-tgt MLwP CoeClass,
@@ -128,7 +129,7 @@ declare Module B :- std.do! [
   std.flatten [
       Factories, [ClassAlias], [is-structure Structure],
       NewJoins, [class-def CurrentClass], GRDepsClauses,
-      [gref-deps GRPack MLwP], [StructKeyClause]
+      [gref-deps GRPack MLwP], [StructKeyClause], PHClauses
     ]
     NewClauses,
   std.forall NewClauses (c\ log.coq.env.accumulate current "hb.db" (clause _ _ c)),
@@ -632,12 +633,12 @@ pack-body.aux PL T BuildC PackS  Body :- !, std.do! [
   mk-app (global PackS) {std.append PL [T, Class]} Body
 ].
 
-pred declare-auto-infer-params-abbrev i:structure, i:mixins, o:located.
-declare-auto-infer-params-abbrev GR MLwP (loc-abbreviation Abbrev) :-
+pred declare-auto-infer-params-abbrev i:structure, i:mixins, o:located, o:list prop.
+declare-auto-infer-params-abbrev GR MLwP (loc-abbreviation Abbrev) [phant-abbrev GR (const PhC) Abbrev] :-
   get-option "infer" Map, !,
   Map => mk-infer (global GR) MLwP PhT,
-  phant.add-abbreviation "type" PhT _ Abbrev.
-declare-auto-infer-params-abbrev GR _ (loc-gref GR).
+  phant.add-abbreviation "type" PhT PhC Abbrev.
+declare-auto-infer-params-abbrev GR _ (loc-gref GR) [].
 
 pred mk-infer i:term, i:mixins, o:phant-term.
 mk-infer T (w-params.nil _ _ _) PH :- phant.init T PH.

--- a/HB/structure.elpi
+++ b/HB/structure.elpi
@@ -66,13 +66,6 @@ declare Module B :- std.do! [
   log.coq.env.add-const-noimplicits "pack_" Pack _ @transparent! ConstPack,
   GRPack = const ConstPack,
 
-  if-verbose (coq.say {header} "declaring pack abbreviation"),
-  (ClassAlias => class-def CurrentClass =>
-    GRDepsClauses => MixinFirstClass => gref-deps GRPack MLwP =>
-      phant.of-gref tt GRPack [] PhRepack),
-  if-verbose (coq.say {header} "declaring pack abbreviation =" PhRepack),
-  phant.add-abbreviation "pack" PhRepack _ PackAbbrev,
-
   if-arg-sort (
     if-verbose (coq.say {header} "define arg_sort"),
     std.assert-ok! (coq.typecheck SortProjection SortProjTy)
@@ -83,6 +76,12 @@ declare Module B :- std.do! [
   if-verbose (coq.say {header} "start module Exports"),
 
   log.coq.env.begin-module "Exports" none,
+
+  %(ClassAlias => class-def CurrentClass =>
+  %  GRDepsClauses => MixinFirstClass => gref-deps GRPack MLwP =>
+  %    phant.of-gref tt GRPack [] PhRepack),
+  %if-verbose (coq.say {header} "declaring pack abbreviation =" PhRepack),
+  % phant.add-abbreviation "pack" PhRepack _ PackAbbrev,
   
   if (get-option "short.type" ShortType) (
     if-verbose (coq.say {header} "short name for type:" ShortType),
@@ -93,12 +92,18 @@ declare Module B :- std.do! [
     ]) (@global! => log.coq.notation.add-abbreviation
       ShortType 0 (global Structure) ff _)) true,
 
+  coq.mk-app (global Structure) {coq.mk-n-holes {w-params.nparams MLwP}} HB_Instance,
   if (get-option "short.pack" ShortPack) (std.do! [
     if-verbose (coq.say {header} "declaring pack abbreviation:" ShortPack),
-    coq.notation.abbreviation-body PackAbbrev NPackAbbrev PackAbbrevTrm,
-    @global! => log.coq.notation.add-abbreviation
-      ShortPack NPackAbbrev PackAbbrevTrm ff _
-    ]) true,
+    % coq.notation.abbreviation-body PackAbbrev NPackAbbrev PackAbbrevTrm,
+    % @global! => log.coq.notation.add-abbreviation
+    %  ShortPack NPackAbbrev PackAbbrevTrm ff _
+      coq.notation.add-abbreviation-for-tactic ShortPack "HB.pack_for" [trm HB_Instance]
+    ]) (std.do! [
+    PackAbbrevName is Module ^ ".pack",
+    if-verbose (coq.say {header} "declaring pack abbreviation:" PackAbbrevName),
+    coq.notation.add-abbreviation-for-tactic PackAbbrevName "HB.pack_for" [trm HB_Instance],
+  ]),
 
   if-verbose (coq.say {header} "making coercion from type to target"),
   synthesis.infer-coercion-tgt MLwP CoeClass,
@@ -167,8 +172,8 @@ declare Module B :- std.do! [
     ]
     ),
 
-  std.flatten {std.map NewMixins mixin->factories} NewFactories,
-  NewClauses => std.forall NewFactories instance.declare-factory-sort-factory,
+  % std.flatten {std.map NewMixins mixin->factories} NewFactories,
+  % NewClauses => std.forall NewFactories instance.declare-factory-sort-factory,
 
   log.coq.env.end-module-name "EtaAndMixinExports" EtaExports,
 

--- a/HB/structure.elpi
+++ b/HB/structure.elpi
@@ -103,7 +103,7 @@ declare Module B :- std.do! [
     PackAbbrevName is Module ^ ".pack",
     if-verbose (coq.say {header} "declaring pack abbreviation:" PackAbbrevName),
     coq.notation.add-abbreviation-for-tactic PackAbbrevName "HB.pack_for" [trm HB_Instance],
-    ]),
+  ]),
 
   if-verbose (coq.say {header} "making coercion from type to target"),
   synthesis.infer-coercion-tgt MLwP CoeClass,
@@ -156,21 +156,20 @@ declare Module B :- std.do! [
 
   @global! => log.coq.notation.add-abbreviation "on" 1
     {{fun T => (lp:{{ ClassOfAbbrev_ {{_}} }} : (lp:AppClassHoles T)) }} tt
-    _OnAbbrev,
+    OnAbbrev,
 
   log.coq.env.begin-module "EtaAndMixinExports" none,
 
   if (get-option "primitive" tt) true (
-    true
-    % if-verbose (coq.say {header} "eta expanded instances"),
-    % NewClauses => std.do! [
-    %   w-params.fold MLwP mk-fun
-    %     (private.mk-hb-eta.on Structure SortProjection OnAbbrev) EtaInstanceBody,
-    %   w-params.fold MLwP (mk-parameter explicit)
-    %     (private.mk-hb-eta.arity Structure ClassName SortProjection)
-    %     EtaInstanceArity,
-    %   instance.declare-const "_" EtaInstanceBody EtaInstanceArity _
-    % ]
+    if-verbose (coq.say {header} "eta expanded instances"),
+    NewClauses => std.do! [
+      w-params.fold MLwP mk-fun
+        (private.mk-hb-eta.on Structure SortProjection OnAbbrev) EtaInstanceBody,
+      w-params.fold MLwP (mk-parameter explicit)
+        (private.mk-hb-eta.arity Structure ClassName SortProjection)
+        EtaInstanceArity,
+      instance.declare-const "_" EtaInstanceBody EtaInstanceArity _
+    ]
     ),
 
   % std.flatten {std.map NewMixins mixin->factories} NewFactories,
@@ -702,32 +701,32 @@ sigT->list-w-params {{ lib:@hb.sigT _ lp:{{ fun N Ty B }} }} L C :-
   @pi-decl N Ty t\
     product->triples (B t) (Rest t) C.
 
-% pred mk-hb-eta.on i:structure, i:term, i:abbreviation,
-%   i:list term, i:name, i:term, i:A, o:term.
-% mk-hb-eta.on Structure SortProjection OnAbbrev
-%     Params NT _T _ (fun NT Ty Body) :- !, std.do! [
-%   coq.mk-app (global Structure) Params Ty,
-%   @pi-decl NT Ty s\ sigma Tm\ std.do! [
-%     coq.mk-app {{lib:@hb.eta}}
-%       [_, {coq.mk-app SortProjection {std.append Params [s]}}]
-%       Tm,
-%     std.assert-ok! (coq.typecheck Tm _) "HB: eta illtyped",
-%     coq.notation.abbreviation OnAbbrev [Tm] (Body s)
-%   ]
-% ].
-% 
-% pred mk-hb-eta.arity i:structure, i:classname, i:term, i:list term,
-%   i:name, i:term, i:A, o:arity.
-% mk-hb-eta.arity Structure ClassName SortProjection
-%     Params NT _T _ Out :- !, std.do! [
-%   coq.mk-app (global Structure) Params Ty,
-%   (@pi-decl NT Ty s\ sigma Tm\ std.do! [
-%     coq.mk-app {{lib:@hb.eta}}
-%       [_, {coq.mk-app SortProjection {std.append Params [s]}}] Tm,
-%     std.assert-ok! (coq.typecheck Tm _) "HB: eta illtyped",
-%     coq.mk-app (global ClassName) {std.append Params [Tm]} (Concl s)
-%   ]),
-%   Out = parameter {coq.name->id NT} explicit Ty s\ arity (Concl s)
-% ].
-% 
+pred mk-hb-eta.on i:structure, i:term, i:abbreviation,
+  i:list term, i:name, i:term, i:A, o:term.
+mk-hb-eta.on Structure SortProjection OnAbbrev
+    Params NT _T _ (fun NT Ty Body) :- !, std.do! [
+  coq.mk-app (global Structure) Params Ty,
+  @pi-decl NT Ty s\ sigma Tm\ std.do! [
+    coq.mk-app {{lib:@hb.eta}}
+      [_, {coq.mk-app SortProjection {std.append Params [s]}}]
+      Tm,
+    std.assert-ok! (coq.typecheck Tm _) "HB: eta illtyped",
+    coq.notation.abbreviation OnAbbrev [Tm] (Body s)
+  ]
+].
+
+pred mk-hb-eta.arity i:structure, i:classname, i:term, i:list term,
+  i:name, i:term, i:A, o:arity.
+mk-hb-eta.arity Structure ClassName SortProjection
+    Params NT _T _ Out :- !, std.do! [
+  coq.mk-app (global Structure) Params Ty,
+  (@pi-decl NT Ty s\ sigma Tm\ std.do! [
+    coq.mk-app {{lib:@hb.eta}}
+      [_, {coq.mk-app SortProjection {std.append Params [s]}}] Tm,
+    std.assert-ok! (coq.typecheck Tm _) "HB: eta illtyped",
+    coq.mk-app (global ClassName) {std.append Params [Tm]} (Concl s)
+  ]),
+  Out = parameter {coq.name->id NT} explicit Ty s\ arity (Concl s)
+].
+
 }}

--- a/HB/structure.elpi
+++ b/HB/structure.elpi
@@ -71,9 +71,9 @@ declare Module B :- std.do! [
     GRDepsClauses => MixinFirstClass => gref-deps GRPack MLwP =>
       phant.of-gref tt GRPack [] PhRepack),
   if-verbose (coq.say "HB: declaring pack abbreviation =" PhRepack),
-  %phant.add-abbreviation "pack" PhRepack _ PackAbbrev,
+  phant.add-abbreviation "pack" PhRepack _ PackAbbrev,
   
-  coq.notation.add-abbreviation-for-tactic [Module, "pack"] "hb_instance" [trm (global Structure)],
+  coq.notation.add-abbreviation-for-tactic [Module, "xpack"] "hb_instance" [trm (global Structure)],
 
   if-arg-sort (
     if-verbose (coq.say "HB: define arg_sort"),

--- a/HB/structure.elpi
+++ b/HB/structure.elpi
@@ -72,6 +72,8 @@ declare Module B :- std.do! [
       phant.of-gref tt GRPack [] PhRepack),
   if-verbose (coq.say "HB: declaring pack abbreviation =" PhRepack),
   phant.add-abbreviation "pack" PhRepack _ PackAbbrev,
+  
+  @global! => log.coq.notation.add-abbreviation "xpack" 0 (global Structure) ff _,
 
   if-arg-sort (
     if-verbose (coq.say "HB: define arg_sort"),

--- a/HB/structure.elpi
+++ b/HB/structure.elpi
@@ -22,7 +22,7 @@ declare Module B :- std.do! [
   synthesis.list-w-params.check-key MLwP,
 
   if (ClosureCheck = tt, not({std.length PML} = {std.length ML}))
-     (coq.warn "HB: pulling in dependencies:" {std.map {std.list-diff ML PML} nice-gref->string}
+     (coq.warning "HB" "HB.implicit-structure-dependency" "pulling in dependencies:" {std.map {std.list-diff ML PML} nice-gref->string}
                "\nPlease list them or end the declaration with '&'")
      true,
 
@@ -119,7 +119,7 @@ declare Module B :- std.do! [
 
   if (ClassName = indt ClassInd) (std.do![
     if-verbose (coq.say "HB: exporting coercions from class to mixins"),
-    std.forall {coq.CS.canonical-projections ClassInd}
+    std.forall {coq.env.projections ClassInd}
       (private.export-mixin-coercion ClassName)
     ])
     (coq.say "declare:" ClassName "should be an inductive", fail),
@@ -282,7 +282,7 @@ export-1-operation M Struct Psort Pclass MwP (some Poperation) EXI EXO :- !, std
 pred export-operations.aux i:structure, i:term, i:term, i:one-w-params mixinname, i:list prop, o:list prop.
 export-operations.aux Struct ProjSort ProjClass MwP EX1 EX2 :- !, std.do! [
   w-params_1 MwP (indt M),
-  coq.CS.canonical-projections M Poperations,
+  coq.env.projections M Poperations,
   std.fold Poperations EX1 (export-1-operation (indt M) Struct ProjSort ProjClass MwP) EX2,
 ].
 
@@ -515,7 +515,7 @@ declare-class+structure MLwP (indt ClassInd) (indt StructureInd) SortProjection 
     (@primitive! => log.coq.env.add-indt ClassDeclaration ClassInd)
     (log.coq.env.add-indt ClassDeclaration ClassInd),
 
-  coq.CS.canonical-projections ClassInd Projs,
+  coq.env.projections ClassInd Projs,
   % TODO: put this code in a named clause
   w-params.nparams MLwP NParams,
   std.map2 {list-w-params_list MLwP} Projs (m\ p\ r\ sigma P\
@@ -533,7 +533,7 @@ declare-class+structure MLwP (indt ClassInd) (indt StructureInd) SortProjection 
     (@primitive! => log.coq.env.add-indt StructureDeclaration StructureInd)
     (log.coq.env.add-indt StructureDeclaration StructureInd),
 
-  coq.CS.canonical-projections StructureInd [some SortP, some ClassP],
+  coq.env.projections StructureInd [some SortP, some ClassP],
   global (const SortP) = SortProjection,
   global (const ClassP) = ClassProjection,
 ].

--- a/HB/structure.elpi
+++ b/HB/structure.elpi
@@ -83,10 +83,6 @@ declare Module B :- std.do! [
   %if-verbose (coq.say "HB: declaring pack abbreviation =" PhRepack),
   % phant.add-abbreviation "pack" PhRepack _ PackAbbrev,
   
-  coq.mk-app (global Structure) {coq.mk-n-holes {w-params.nparams MLwP}} HB_Instance,
-
-  coq.notation.add-abbreviation-for-tactic [Module, "pack"] "hb_instance" [trm HB_Instance],
-
   if (get-option "short.type" ShortType) (
     if-verbose (coq.say "HB: short name for type:" ShortType),
     if (LocType = loc-abbreviation StrTypeAbbrev) (std.do! [
@@ -102,10 +98,10 @@ declare Module B :- std.do! [
     % coq.notation.abbreviation-body PackAbbrev NPackAbbrev PackAbbrevTrm,
     % @global! => log.coq.notation.add-abbreviation
     %  ShortPack NPackAbbrev PackAbbrevTrm ff _
-      coq.notation.add-abbreviation-for-tactic [ShortPack] "hb_instance" [trm HB_Instance]
+      coq.notation.add-abbreviation-for-tactic [ShortPack] "hb_pack_for" [trm HB_Instance]
     ]) (std.do! [
     if-verbose (coq.say "HB: declaring pack abbreviation"),
-    coq.notation.add-abbreviation-for-tactic [Module, "pack"] "hb_instance" [trm HB_Instance],
+    coq.notation.add-abbreviation-for-tactic [Module, "pack"] "hb_pack_for" [trm HB_Instance],
     ]),
 
   if-verbose (coq.say "HB: making coercion from type to target"),

--- a/HB/structure.elpi
+++ b/HB/structure.elpi
@@ -94,14 +94,15 @@ declare Module B :- std.do! [
 
   coq.mk-app (global Structure) {coq.mk-n-holes {w-params.nparams MLwP}} HB_Instance,
   if (get-option "short.pack" ShortPack) (std.do! [
-    if-verbose (coq.say "HB: short name for type:" ShortPack),
+    if-verbose (coq.say "HB: declaring pack abbreviation:" ShortPack),
     % coq.notation.abbreviation-body PackAbbrev NPackAbbrev PackAbbrevTrm,
     % @global! => log.coq.notation.add-abbreviation
     %  ShortPack NPackAbbrev PackAbbrevTrm ff _
-      coq.notation.add-abbreviation-for-tactic [ShortPack] "hb_pack_for" [trm HB_Instance]
+      coq.notation.add-abbreviation-for-tactic ShortPack "HB.pack_for" [trm HB_Instance]
     ]) (std.do! [
-    if-verbose (coq.say "HB: declaring pack abbreviation"),
-    coq.notation.add-abbreviation-for-tactic [Module, "pack"] "hb_pack_for" [trm HB_Instance],
+    PackAbbrevName is Module ^ ".pack",
+    if-verbose (coq.say "HB: declaring pack abbreviation:" PackAbbrevName),
+    coq.notation.add-abbreviation-for-tactic PackAbbrevName "HB.pack_for" [trm HB_Instance],
     ]),
 
   if-verbose (coq.say "HB: making coercion from type to target"),

--- a/HB/structure.elpi
+++ b/HB/structure.elpi
@@ -344,8 +344,8 @@ mk-coe-structure-body StructureF StructureT TC Coercion SortProjection ClassProj
     {coq.mk-n-holes {factory-nparams TC}} PackPH,
 
   SCoeBody = {{ fun s : lp:StructureP =>
-     let T := lp:SortP s in
-     lp:PackPH T (lp:CoercionP T (lp:ClassP s)) }},
+     (* let T := lp:SortP s in*)
+     lp:PackPH (lp:SortP s) (lp:CoercionP (lp:SortP s) (lp:ClassP s)) }},
 ].
 
 % [declare-coercion P1 P2 C1 C2] declares a structure and a class coercion

--- a/README.md
+++ b/README.md
@@ -134,6 +134,9 @@ opam install coq-hierarchy-builder
   - `HB.instance` declares a structure instance,
   - `HB.declare` declares a context with parameters, key and mixins.
 
+- HB core tactic-in-term:
+  - `HB.pack` to synthesize a structure instance in the middle of a term.
+
 - HB utility commands:
   - `HB.export` exports a module and schedules it for re-export
   - `HB.reexport` exports all modules, instances and constants scheduled for

--- a/_CoqProject.test-suite
+++ b/_CoqProject.test-suite
@@ -60,7 +60,7 @@ tests/funclass.v
 tests/local_instance.v
 tests/lock.v
 tests/not_same_key.v
-tests/factory_sort.v
+#tests/factory_sort.v
 tests/factory_sort_tac.v
 tests/declare.v
 tests/short.v

--- a/_CoqProject.test-suite
+++ b/_CoqProject.test-suite
@@ -63,7 +63,7 @@ tests/not_same_key.v
 tests/factory_sort.v
 tests/factory_sort_tac.v
 tests/declare.v
-#tests/short.v
+tests/short.v
 tests/primitive_records.v
 tests/non_forgetful_inheritance.v
 

--- a/_CoqProject.test-suite
+++ b/_CoqProject.test-suite
@@ -61,6 +61,7 @@ tests/local_instance.v
 tests/lock.v
 tests/not_same_key.v
 tests/factory_sort.v
+tests/factory_sort_tac.v
 tests/declare.v
 tests/short.v
 tests/primitive_records.v

--- a/_CoqProject.test-suite
+++ b/_CoqProject.test-suite
@@ -66,6 +66,7 @@ tests/declare.v
 tests/short.v
 tests/primitive_records.v
 tests/non_forgetful_inheritance.v
+tests/fix_loop.v
 
 -R tests HB.tests
 -R examples HB.examples

--- a/_CoqProject.test-suite
+++ b/_CoqProject.test-suite
@@ -63,7 +63,7 @@ tests/not_same_key.v
 tests/factory_sort.v
 tests/factory_sort_tac.v
 tests/declare.v
-tests/short.v
+#tests/short.v
 tests/primitive_records.v
 tests/non_forgetful_inheritance.v
 

--- a/_CoqProject.test-suite
+++ b/_CoqProject.test-suite
@@ -1,10 +1,8 @@
--arg -w -arg +all
 -arg -w -arg -redundant-canonical-projection
 -arg -w -arg -projection-no-head-constant
 -arg -w -arg -abstract-large-number
 -arg -w -arg -disj-pattern-notation
 -arg -w -arg -notation-overridden
--arg -w -arg HB
 
 examples/readme.v
 examples/hulk.v

--- a/_CoqProject.test-suite
+++ b/_CoqProject.test-suite
@@ -1,3 +1,11 @@
+-arg -w -arg +all
+-arg -w -arg -redundant-canonical-projection
+-arg -w -arg -projection-no-head-constant
+-arg -w -arg -abstract-large-number
+-arg -w -arg -disj-pattern-notation
+-arg -w -arg -notation-overridden
+-arg -w -arg HB
+
 examples/readme.v
 examples/hulk.v
 

--- a/coq-hierarchy-builder.opam
+++ b/coq-hierarchy-builder.opam
@@ -12,7 +12,7 @@ build: [ [ make "build"]
          [ make "test-suite" ] {with-test}
        ]
 install: [ make "install" ]
-depends: [ "coq-elpi" { (>= "1.10.3" & < "1.11~") | = "dev" } ]
+depends: [ "coq-elpi" { (>= "1.11.0" & < "1.12~") | = "dev" } ]
 conflicts: [ "coq-hierarchy-builder-shim" ]
 synopsis: "High level commands to declare and evolve a hierarchy based on packed classes"
 description: """

--- a/coq-hierarchy-builder.opam
+++ b/coq-hierarchy-builder.opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/math-comp/hierarchy-builder/issues"
 dev-repo: "git+https://github.com/math-comp/hierarchy-builder"
 
 build: [ [ make "build"]
-         [ make "test-suite" ]  # {with-test} waiting https://github.com/coq-community/docker-coq-action/pull/48
+         [ make "test-suite" ] {with-test}
        ]
 install: [ make "install" ]
 depends: [ "coq-elpi" { (>= "1.10.2" & < "1.11~") | = "dev" } ]

--- a/coq-hierarchy-builder.opam
+++ b/coq-hierarchy-builder.opam
@@ -12,7 +12,7 @@ build: [ [ make "build"]
          [ make "test-suite" ] {with-test}
        ]
 install: [ make "install" ]
-depends: [ "coq-elpi" { (>= "1.10.2" & < "1.11~") | = "dev" } ]
+depends: [ "coq-elpi" { (>= "1.10.3" & < "1.11~") | = "dev" } ]
 conflicts: [ "coq-hierarchy-builder-shim" ]
 synopsis: "High level commands to declare and evolve a hierarchy based on packed classes"
 description: """

--- a/examples/demo1/hierarchy_2.v
+++ b/examples/demo1/hierarchy_2.v
@@ -68,14 +68,6 @@ HB.factory Record Ring_of_AddComoid A of AddComoid A := {
   mulrDr : right_distributive mul add;
 }.
 
-Section test.
-HB.declare Context A of AddComoid A.
-Print Canonical Projections A.
-Variable (f : Ring_of_AddComoid A).
-HB.instance Definition _ : AddComoid_of_TYPE f := AddComoid.on f.
-End test.
-Print Canonical Projections Ring_of_AddComoid.sort.
-
 
 HB.builders Context A (a : Ring_of_AddComoid A).
 

--- a/examples/demo2/classical.v
+++ b/examples/demo2/classical.v
@@ -439,8 +439,8 @@ Definition ex_in C B x y :=  let: F^* := B in (C && F)^*.
 End Definitions.
 
 
-Notation "`[ x | B ]" := (quant0p (fun x => B x)) (at level 0, x ident).
-Notation "`[ x : T | B ]" := (quant0p (fun x : T => B x)) (at level 0, x ident).
+Notation "`[ x | B ]" := (quant0p (fun x => B x)) (at level 0, x name).
+Notation "`[ x : T | B ]" := (quant0p (fun x : T => B x)) (at level 0, x name).
 
 Module Exports.
 
@@ -603,7 +603,7 @@ apply: (asbool_equiv_eqP existsp_asboolPn);
   by split=> -[x h]; exists x; apply/negP.
 Qed.
 Reserved Notation "[ 'set' x : T | P ]"
-  (at level 0, x at level 99, only parsing).
+  (at level 0, x at level 99).
 Reserved Notation "[ 'set' x | P ]"
   (at level 0, x, P at level 99, format "[ 'set'  x  |  P ]").
 Reserved Notation "[ 'set' E | x 'in' A ]" (at level 0, E, x at level 99,
@@ -972,6 +972,7 @@ Definition xget {T} x0 (P : set T) : T :=
   if pselect (exists x : T, `[<P x>]) isn't left exP then x0
   else projT1 (cid exP).
 
+Unset Auto Template Polymorphism.
 CoInductive xget_spec {T} x0 (P : set T) : T -> Prop -> Type :=
 | XGetSome x of x = xget x0 P & P x : xget_spec x0 P x True
 | XGetNone of (forall x, ~ P x) : xget_spec x0 P x0 False.

--- a/examples/demo2/stage10.v
+++ b/examples/demo2/stage10.v
@@ -1,4 +1,4 @@
-From Coq Require Import ssreflect ssrfun ssrbool ZArith QArith.
+From Coq Require Import ssreflect ssrfun ssrbool ZArith QArith Qcanon.
 From HB Require Import structures.
 
 Require Import classical.
@@ -130,7 +130,7 @@ HB.mixin Record Topological T := {
 }.
 HB.structure Definition TopologicalSpace := { A of Topological A }.
 
-Hint Extern 0 (open setT) => now apply: open_setT : core.
+#[export] Hint Extern 0 (open setT) => now apply: open_setT : core.
 
 HB.factory Record TopologicalBase T := {
   open_base : set (set T);
@@ -218,7 +218,7 @@ HB.instance Definition Z_ring_axioms :=
 Example test1 (m n : Z) : (m + n) - n + 0 = m.
 Proof. by rewrite addrK addr0. Qed.
 
-Require Import Qcanon.
+Import Qcanon.
 Search _ Qc "plus" "opp".
 
 Lemma Qcplus_opp_l q : - q + q = 0.

--- a/examples/demo2/stage11.v
+++ b/examples/demo2/stage11.v
@@ -1,6 +1,5 @@
-From Coq Require Import ssreflect ssrfun ssrbool ZArith QArith.
+From Coq Require Import ssreflect ssrfun ssrbool ZArith QArith Qcanon.
 From HB Require Import structures.
-
 Require Import classical.
 
 Declare Scope hb_scope.
@@ -133,7 +132,7 @@ HB.mixin Record Topological T := {
 }.
 HB.structure Definition TopologicalSpace := { A of Topological A }.
 
-Hint Extern 0 (open setT) => now apply: open_setT : core.
+#[export] Hint Extern 0 (open setT) => now apply: open_setT : core.
 
 HB.factory Record TopologicalBase T := {
   open_base : set (set T);
@@ -352,7 +351,7 @@ HB.instance Definition Z_ring_axioms :=
 Example test1 (m n : Z) : (m + n) - n + 0 = m.
 Proof. by rewrite addrK addr0. Qed.
 
-Require Import Qcanon.
+Import Qcanon.
 Lemma Qcplus_opp_l q : - q + q = 0.
 Proof. by rewrite Qcplus_comm Qcplus_opp_r. Qed.
 

--- a/examples/hulk.v
+++ b/examples/hulk.v
@@ -195,7 +195,7 @@ HB.instance Definition _ := IsContractible.Build (link canfg) link_def link_all_
 End TransferSingleton.
 
 (* We assume a known type B which is both an Equality and a Singleton *)
-Axioms B : Type.
+Axiom B : Type.
 
 Axiom testB : B -> B -> bool.
 Axiom testOKB : forall x y, reflect (x = y) (testB x y).

--- a/examples/readme.v
+++ b/examples/readme.v
@@ -38,3 +38,11 @@ Check AbelianGrp.on Z.
 
 HB.graph "readme.dot".
 HB.about Z.
+
+Section Test.
+HB.declare Context (T : Type) (p : AddComoid_of_Type T) (q : AbelianGrp_of_AddComoid T).
+
+Goal forall x : T, x + -x = 0.
+Abort.
+
+End Test.

--- a/hb.ml
+++ b/hb.ml
@@ -35,7 +35,7 @@ type patch = {
 }
 
 let parse_one_patch text =
-  let r = Str.regexp "[^,]+, characters \\([0-9]+\\)-\\([0-9]+\\).*" in
+  let r = Str.regexp ".*characters \\([0-9]+\\)-\\([0-9]+\\).*" in
   let beginning = String.index text '\n' in
   let header = String.sub text 0 beginning in
   let start = int_of_string @@ Str.replace_first r "\\1" header in

--- a/shim/structures.v
+++ b/shim/structures.v
@@ -8,3 +8,4 @@ Definition id_phant {T} {t : T} (x : phantom T t) := x.
 Definition nomsg : error_msg := NoMsg.
 Definition is_not_canonically_a x := IsNotCanonicallyA x.
 Definition new {T} (x : T) := x.
+Definition eta {T} (x : T) := x.

--- a/shim/structures.v
+++ b/shim/structures.v
@@ -8,4 +8,3 @@ Definition id_phant {T} {t : T} (x : phantom T t) := x.
 Definition nomsg : error_msg := NoMsg.
 Definition is_not_canonically_a x := IsNotCanonicallyA x.
 Definition new {T} (x : T) := x.
-Definition eta {T} (x : T) := x.

--- a/structures.v
+++ b/structures.v
@@ -406,7 +406,26 @@ Elpi Export HB.mixin.
 
 *)
 
-Elpi Tactic hb_pack.
+Elpi Tactic HB.pack_for.
+Elpi Accumulate Db hb.db.
+Elpi Accumulate File "HB/common/stdpp.elpi".
+Elpi Accumulate File "HB/common/utils.elpi".
+Elpi Accumulate File "HB/common/log.elpi".
+Elpi Accumulate File "HB/common/database.elpi".
+Elpi Accumulate File "HB/common/synthesis.elpi".
+Elpi Accumulate File "HB/pack.elpi".
+Elpi Accumulate lp:{{
+
+solve (goal _ _ _ _ [trm Ty | Args] as G) GLS :- with-attributes (with-logging (std.spy-do! [
+  pack.main Ty Args Instance,
+  std.assert! (log.refine Instance G GLS) "HB.pack: the instance does not solve the goal",
+])).
+
+}}.
+Elpi Typecheck.
+Elpi Export HB.pack_for.
+
+Elpi Tactic HB.pack.
 Elpi Accumulate Db hb.db.
 Elpi Accumulate File "HB/common/stdpp.elpi".
 Elpi Accumulate File "HB/common/utils.elpi".
@@ -423,29 +442,7 @@ solve (goal _ _ Ty _ Args as G) GLS :- with-attributes (with-logging (std.do! [
 
 }}.
 Elpi Typecheck.
-
-Elpi Tactic hb_pack_for.
-Elpi Accumulate Db hb.db.
-Elpi Accumulate File "HB/common/stdpp.elpi".
-Elpi Accumulate File "HB/common/utils.elpi".
-Elpi Accumulate File "HB/common/log.elpi".
-Elpi Accumulate File "HB/common/database.elpi".
-Elpi Accumulate File "HB/common/synthesis.elpi".
-Elpi Accumulate File "HB/pack.elpi".
-Elpi Accumulate lp:{{
-
-solve (goal _ _ _ _ [trm Ty | Args] as G) GLS :- with-attributes (with-logging (std.do! [
-  pack.main Ty Args Instance,
-  std.assert! (log.refine Instance G GLS) "HB.pack: the instance does not solve the goal",
-])).
-
-}}.
-Elpi Typecheck.
-
-Elpi Query lp:{{
-  coq.notation.add-abbreviation-for-tactic ["HB", "pack"] "hb_pack" [],
-  coq.notation.add-abbreviation-for-tactic ["HB", "pack_for"] "hb_pack_for" []
-}}.
+Elpi Export HB.pack.
 
 (* %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% *)
 (* %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% *)

--- a/structures.v
+++ b/structures.v
@@ -416,7 +416,7 @@ Elpi Accumulate File "HB/common/synthesis.elpi".
 Elpi Accumulate File "HB/pack.elpi".
 Elpi Accumulate lp:{{
 
-solve (goal _ _ _ _ [trm Ty | Args] as G) GLS :- with-attributes (with-logging (std.spy-do! [
+solve (goal _ _ _ _ [trm Ty | Args] as G) GLS :- with-attributes (with-logging (std.do! [
   pack.main Ty Args Instance,
   std.assert! (log.refine Instance G GLS) "HB.pack: the instance does not solve the goal",
 ])).

--- a/structures.v
+++ b/structures.v
@@ -412,7 +412,7 @@ elab-factories [trm FactorySkel|More] [Factory|Factories] :-
 solve (goal _ _ Statement _ Args as G) GLS :- with-attributes (with-logging (std.do! [
   if2 (Args = [trm Ty, trm TSkel, FactorySkel | MoreFactories]) true
       (Args = [trm TSkel, FactorySkel], Ty = Statement, MoreFactories = []) true
-      (coq.error "usage: hb_instance [Ty] T F"),
+      (coq.error "usage: hb_instance [Ty] T F1 .. FN"),
 
   std.assert-ok! (coq.elaborate-ty-skeleton TSkel _ T) "not a type",
 
@@ -429,10 +429,10 @@ solve (goal _ _ Statement _ Args as G) GLS :- with-attributes (with-logging (std
 
 }}.
 Elpi Typecheck.
-Tactic Notation "hb_instance" open_constr(s) open_constr(f) :=
-  elpi hb_instance ltac_term:(s) ltac_term:(f).
-Tactic Notation "hb_instance" open_constr(t) open_constr(s) open_constr(f) :=
-  elpi hb_instance ltac_term:(t) ltac_term:(s) ltac_term:(f).
+Tactic Notation "hb_instance" open_constr(s) open_constr_list(f) :=
+  elpi hb_instance ltac_term:(s) ltac_term_list:(f).
+Tactic Notation "hb_instance" open_constr(t) open_constr(s) open_constr_list(f) :=
+  elpi hb_instance ltac_term:(t) ltac_term:(s) ltac_term_list:(f).
 
 Elpi Query lp:{{
   coq.notation.add-abbreviation-for-tactic ["HB", "pack"] "hb_instance" []

--- a/structures.v
+++ b/structures.v
@@ -9,6 +9,7 @@ Definition id_phant {T} {t : T} (x : phantom T t) := x.
 Definition nomsg : error_msg := NoMsg.
 Definition is_not_canonically_a x := IsNotCanonicallyA x.
 Definition new {T} (x : T) := x.
+Definition eta {T} (x : T) := x.
 
 (* ********************* structures ****************************** *)
 From elpi Require Import elpi.
@@ -29,6 +30,7 @@ Register Coq.ssr.ssreflect.Phantom as hb.Phantom.
 Register Coq.Init.Logic.eq as hb.eq.
 Register Coq.Init.Logic.eq_refl as hb.erefl.
 Register new as hb.new.
+Register eta as hb.eta.
 
 #[deprecated(since="HB 1.0.1", note="use #[key=...] instead")]
 Notation indexed T := T (only parsing).

--- a/structures.v
+++ b/structures.v
@@ -405,7 +405,7 @@ Elpi Export HB.mixin.
 ]]
 
     If [Structure.type] as parameters [P1..Pn] then you should use
-    [HB.pack P1..Pn T F1..Fn] or
+    [HB.pack T F1..Fn] or
     [HB.pack_for (Structure.type P1..Pn) T F1..Fn]
 
 *)
@@ -473,9 +473,6 @@ HB.structure Definition StructureName params :=
   - [StructureName.sort params] the first projection of the previous structure,
   - [StructureName.clone params T cT] a legacy repackaging function that eta expands
     the canonical [StructureName.type] of [T], using [cT] if provided.
-  - [StructureName.pack params T F] a packaging function that takes a key T
-    and some data F, which can be a convertible type or any factory or mixins
-    and attempts to package them together.
   - [StructureName.class sT : StructureName sT] projects out the class of [sT : StructureName.type params],
   - [StructureName.copy T T' : StructureName T] returns the class of the canonical
     [StructureName.type] of [T], and gives it the type [Structure T]. It is thus
@@ -509,7 +506,7 @@ HB.structure Definition StructureName params :=
     but the only reason is to make sure Coq does not print it.
     Cf #<a href="https://github.com/math-comp/math-comp/blob/17dd3091e7f809c1385b0c0be43d1f8de4fa6be0/mathcomp/fingroup/fingroup.v##L225-L243">#[fingroup.v]#</a>#.
   - [#[short(type="shortName")]] produces the abbreviation [shortName] for [Structure.type]
-  - [#[short(pack="shortName")]] produces the abbreviation [shortName] for [Structure.pack]
+  - [#[short(pack="shortName")]] produces the abbreviation [shortName] for [HB.pack_for Structure.type]
   - [#[primitive]] experimental attribute to make the structure a primitive record,
   - [#[primitive_class]] experimental attribute to make the class a primitive record,
   - [#[verbose]] for a verbose output.

--- a/structures.v
+++ b/structures.v
@@ -401,9 +401,9 @@ solve (goal _ _ Ty _ [trm TSkel, trm FactorySkel] as G) GLS :- std.spy-do! [
   params->holes MLwP Params,
   get-constructor Class KC,
   synthesis.under-mixin-src-from-factory.do! T TClass [
-    synthesis.under-mixin-src-from-factory.do! T Factory [ % FIXME: should be under-new-mixins-src
+    synthesis.under-new-mixin-src-from-factory.do! T Factory (_\
       std.assert! (synthesis.infer-all-args-let Params T KC ClassInstance) "cannot infer"
-    ]
+    )
   ],
   get-constructor Structure KS,
   std.append Params [T, ClassInstance] InstanceArgs,

--- a/structures.v
+++ b/structures.v
@@ -164,7 +164,7 @@ pred exported-op o:mixinname, o:constant, o:constant.
 pred factory-sort o:coercion.
 
 % memory of canonical projections for a structure (X.sort, X.class, X.type)
-pred structure-key o:constant, o:constant, o:inductive.
+pred structure-key o:constant, o:constant, o:structure.
 
 %% database for HB.context %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/structures.v
+++ b/structures.v
@@ -391,10 +391,16 @@ pred hb-instance i:list term, i:gref, i:gref, i:term, i:list term, o:term.
 hb-instance Params KC KS T [Factory|Factories] Instance :-
   synthesis.under-new-mixin-src-from-factory.do! T Factory (_\
     hb-instance Params KC KS T Factories Instance).
+hb-instance Params KC KS T [] Instance :- coq.safe-dest-app T (global _) _, !,
+  synthesis.under-local-canonical-mixins-of.do! T [
+    std.assert-ok! (synthesis.infer-all-args-let Params T KC ClassInstance) "HB: cannot infer the instance",
+    std.append Params [T, ClassInstance] InstanceArgs,
+      Instance = app[global KS | InstanceArgs]
+].
 hb-instance Params KC KS T [] Instance :- std.do! [
   std.assert-ok! (synthesis.infer-all-args-let Params T KC ClassInstance) "HB: cannot infer the instance",
   std.append Params [T, ClassInstance] InstanceArgs,
-      Instance = app[global KS | InstanceArgs]
+    Instance = app[global KS | InstanceArgs]
 ].
 
 pred elab-factories i:list argument, o:list term.

--- a/structures.v
+++ b/structures.v
@@ -416,9 +416,10 @@ Elpi Accumulate File "HB/common/synthesis.elpi".
 Elpi Accumulate File "HB/pack.elpi".
 Elpi Accumulate lp:{{
 
-solve (goal _ _ _ _ [trm Ty | Args] as G) GLS :- with-attributes (with-logging (std.do! [
-  pack.main Ty Args Instance,
-  std.assert! (log.refine Instance G GLS) "HB.pack: the instance does not solve the goal",
+solve (goal _ _ S _ [trm Ty | Args] as G) GLS :- with-attributes (with-logging (std.do! [
+  pack.main Ty Args InstanceSkel,
+  std.assert-ok! (coq.elaborate-skeleton InstanceSkel S Instance) "HB.pack_for: the instance does not solve the goal",
+  log.refine.no_check Instance G GLS,
 ])).
 
 }}.
@@ -436,8 +437,9 @@ Elpi Accumulate File "HB/pack.elpi".
 Elpi Accumulate lp:{{
 
 solve (goal _ _ Ty _ Args as G) GLS :- with-attributes (with-logging (std.do! [
-  pack.main Ty Args Instance,
-  std.assert! (log.refine Instance G GLS) "HB.pack: the instance does not solve the goal",
+  pack.main Ty Args InstanceSkel,
+  std.assert-ok! (coq.elaborate-skeleton InstanceSkel Ty Instance) "HB.pack: the instance does not solve the goal",
+  log.refine.no_check Instance G GLS,
 ])).
 
 }}.

--- a/structures.v
+++ b/structures.v
@@ -419,7 +419,7 @@ solve (goal _ _ Statement _ Args as G) GLS :- with-attributes (with-logging (std
 
   hb-instance Ty T Factory Instance,
 
-  std.assert! (refine Instance G GLS) "the instance does not solve the goal",
+  std.assert! (log.refine Instance G GLS) "the instance does not solve the goal",
 ])).
 
 }}.

--- a/structures.v
+++ b/structures.v
@@ -569,7 +569,7 @@ Elpi Accumulate lp:{{
 main [const-decl Name (some BodySkel) TyWPSkel] :- !,
   with-attributes (with-logging (instance.declare-const Name BodySkel TyWPSkel _)).
 main [T0, F0] :- !,
-  coq.warn "The syntax \"HB.instance Key FactoryInstance\" is deprecated, use \"HB.instance Definition\" instead",
+  coq.warning "HB" "HB.deprecated" "The syntax \"HB.instance Key FactoryInstance\" is deprecated, use \"HB.instance Definition\" instead",
   with-attributes (with-logging (instance.declare-existing T0 F0)).
 
 main _ :- coq.error "Usage: HB.instance Definition <Name> := <Builder> T ...".
@@ -874,7 +874,7 @@ pred check-or-not i:term.
 check-or-not Skel :-
   coq.version VersionString _ _ _,
   if (get-option "skip" R, rex_match R VersionString)
-     (coq.warn "Skipping test on Coq" VersionString "as requested")
+     (coq.warning "HB" "HB.skip" {get-option "elpi.loc"} "Skipping test on Coq" VersionString "as requested")
      (log.coq.check Skel Ty T Result,
       if (Result = error Msg)
          (if (get-option "fail" tt)

--- a/structures.v
+++ b/structures.v
@@ -391,13 +391,17 @@ Elpi Export HB.mixin.
     you can use [HB.pack_for Structure.type T F].
     
     You can pass zero or more factories like [F] but they must all typecheck
-    in the current context (the type is not enriched progressively). Examples:
+    in the current context (the type is not enriched progressively).
+    Structure instances are projected to their class in order to obtain a
+    factory.
+
+    Examples:
 
 [[
     pose Fa : IsSomething T := IsSomething.Build T ...
     pose A : A.type := HB.pack T Fa.
     pose Fb : IsMore A := IsMore.Build ...
-    pose B := HB.pack_for B.type A Fb.
+    pose B := HB.pack_for B.type T A Fb.
 ]]
 
     If [Structure.type] as parameters [P1..Pn] then you should use

--- a/structures.v
+++ b/structures.v
@@ -418,7 +418,8 @@ solve (goal _ _ _ _ [trm Ty | Args] as G) GLS :- with-attributes (with-logging (
   std.assert! (coq.safe-dest-app Ty (global Structure) _) "not a structure known to HB",
   std.assert! (class-def (class Class Structure MLwP)) "not a structure known to HB",
   w-params.nparams MLwP NParams,
-  std.assert! (std.split-at NParams Args ParamsSkelArgs [trm TSkel|FactoriesSkel]) "not enough arguments",
+  std.assert! ({std.length Args} > NParams) "not enough arguments",
+  std.split-at NParams Args ParamsSkelArgs [trm TSkel|FactoriesSkel],
 
   std.assert! (std.map ParamsSkelArgs (x\r\x = trm r) ParamsSkel) "only terms are accepted",
 

--- a/structures.v
+++ b/structures.v
@@ -387,7 +387,7 @@ Elpi Accumulate File "HB/common/database.elpi".
 Elpi Accumulate File "HB/common/synthesis.elpi".
 Elpi Accumulate lp:{{
 
-solve (goal _ _ Ty _ [trm TSkel, trm FactorySkel] as G) GLS :- std.spy-do! [
+solve (goal _ _ Ty _ [trm TSkel, trm FactorySkel] as G) GLS :- with-attributes (std.do! [
   std.assert-ok! (coq.elaborate-ty-skeleton TSkel _ T) "not a type",
   std.assert-ok! (coq.elaborate-skeleton FactorySkel FTy Factory) "illtyped factory",
   std.assert! (factory? FTy _) "not a factory",
@@ -409,7 +409,7 @@ solve (goal _ _ Ty _ [trm TSkel, trm FactorySkel] as G) GLS :- std.spy-do! [
   std.append Params [T, ClassInstance] InstanceArgs,
   Instance = app[global KS | InstanceArgs],
   std.assert! (refine Instance G GLS) "",
-].
+]).
 
 }}.
 Elpi Typecheck.

--- a/structures.v
+++ b/structures.v
@@ -9,7 +9,6 @@ Definition id_phant {T} {t : T} (x : phantom T t) := x.
 Definition nomsg : error_msg := NoMsg.
 Definition is_not_canonically_a x := IsNotCanonicallyA x.
 Definition new {T} (x : T) := x.
-Definition eta {T} (x : T) := x.
 
 (* ********************* structures ****************************** *)
 From elpi Require Import elpi.
@@ -30,7 +29,6 @@ Register Coq.ssr.ssreflect.Phantom as hb.Phantom.
 Register Coq.Init.Logic.eq as hb.eq.
 Register Coq.Init.Logic.eq_refl as hb.erefl.
 Register new as hb.new.
-Register eta as hb.eta.
 
 #[deprecated(since="HB 1.0.1", note="use #[key=...] instead")]
 Notation indexed T := T (only parsing).

--- a/structures.v
+++ b/structures.v
@@ -163,8 +163,8 @@ pred exported-op o:mixinname, o:constant, o:constant.
 % memory of factory sort coercion
 pred factory-sort o:coercion.
 
-% memory of keys
-pred structure-key o:term, o:gref.
+% memory of canonical projections for a structure (X.sort, X.class, X.type)
+pred structure-key o:constant, o:constant, o:inductive.
 
 %% database for HB.context %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/tests/about.v
+++ b/tests/about.v
@@ -46,6 +46,6 @@ HB.about hierarchy_5_Ring_class__to__hierarchy_5_SemiRing_class.
 HB.about hierarchy_5_Ring__to__hierarchy_5_SemiRing.
 
 (* builder *)
-HB.about Builders_87.hierarchy_5_Ring_of_AddAG__to__hierarchy_5_BiNearRing_of_AddMonoid.
+HB.about Builders_40.hierarchy_5_Ring_of_AddAG__to__hierarchy_5_BiNearRing_of_AddMonoid.
 
 HB.locate BinNums_Z__canonical__hierarchy_5_AddAG.

--- a/tests/about.v
+++ b/tests/about.v
@@ -46,6 +46,6 @@ HB.about hierarchy_5_Ring_class__to__hierarchy_5_SemiRing_class.
 HB.about hierarchy_5_Ring__to__hierarchy_5_SemiRing.
 
 (* builder *)
-HB.about Builders_15.hierarchy_5_Ring_of_AddAG__to__hierarchy_5_BiNearRing_of_AddMonoid.
+HB.about Builders_102.hierarchy_5_Ring_of_AddAG__to__hierarchy_5_BiNearRing_of_AddMonoid.
 
 HB.locate BinNums_Z__canonical__hierarchy_5_AddAG.

--- a/tests/about.v
+++ b/tests/about.v
@@ -46,6 +46,6 @@ HB.about hierarchy_5_Ring_class__to__hierarchy_5_SemiRing_class.
 HB.about hierarchy_5_Ring__to__hierarchy_5_SemiRing.
 
 (* builder *)
-HB.about Builders_40.hierarchy_5_Ring_of_AddAG__to__hierarchy_5_BiNearRing_of_AddMonoid.
+HB.about Builders_15.hierarchy_5_Ring_of_AddAG__to__hierarchy_5_BiNearRing_of_AddMonoid.
 
 HB.locate BinNums_Z__canonical__hierarchy_5_AddAG.

--- a/tests/about.v
+++ b/tests/about.v
@@ -1,4 +1,4 @@
-From Coq Require Import ZArith ssreflect.
+From Coq Require Import ZArith ssrfun ssreflect.
 From HB Require Import structures.
 From HB Require Import demo1.hierarchy_5.
 

--- a/tests/about.v
+++ b/tests/about.v
@@ -46,6 +46,6 @@ HB.about hierarchy_5_Ring_class__to__hierarchy_5_SemiRing_class.
 HB.about hierarchy_5_Ring__to__hierarchy_5_SemiRing.
 
 (* builder *)
-HB.about Builders_102.hierarchy_5_Ring_of_AddAG__to__hierarchy_5_BiNearRing_of_AddMonoid.
+HB.about Builders_40.hierarchy_5_Ring_of_AddAG__to__hierarchy_5_BiNearRing_of_AddMonoid.
 
 HB.locate BinNums_Z__canonical__hierarchy_5_AddAG.

--- a/tests/about.v.out
+++ b/tests/about.v.out
@@ -114,11 +114,6 @@ HB: AddAG.sort is a canonical projection
 HB: AddAG.sort has the following canonical values:
     - Z 
     - Ring.sort (from "./examples/demo1/hierarchy_5.v", line 194)
-    - Ring_of_TYPE.sort (from "./examples/demo1/hierarchy_5.v", line 165)
-    - Ring_of_AddComoid.sort (from "./examples/demo1/hierarchy_5.v", line 142)
-    - Ring_of_AddAG.sort (from "./examples/demo1/hierarchy_5.v", line 108)
-    - AddAG_of_TYPE.sort (from "./examples/demo1/hierarchy_5.v", line 51)
-    - AddAG_of_AddComoid.sort (from "./examples/demo1/hierarchy_5.v", line 44)
     - @eta 
 
 HB: AddAG.sort is a coercion from hierarchy_5.AddAG to Sortclass

--- a/tests/about.v.out
+++ b/tests/about.v.out
@@ -114,7 +114,6 @@ HB: AddAG.sort is a canonical projection
 HB: AddAG.sort has the following canonical values:
     - Z 
     - Ring.sort (from "./examples/demo1/hierarchy_5.v", line 194)
-    - @eta 
 
 HB: AddAG.sort is a coercion from hierarchy_5.AddAG to Sortclass
     (from "./examples/demo1/hierarchy_5.v", line 72)

--- a/tests/about.v.out
+++ b/tests/about.v.out
@@ -131,4 +131,4 @@ HB: hierarchy_5_Ring__to__hierarchy_5_SemiRing is a coercion from
 HB: todo HB.about for builder from hierarchy_5.Ring_of_AddAG to 
 hierarchy_5.BiNearRing_of_AddMonoid
 HB: synthesized in file 
-./tests/about.v, characters 118-242, line 3, column 165
+File "./tests/about.v", line 3, column 165, characters 118-242:

--- a/tests/about.v.out
+++ b/tests/about.v.out
@@ -114,6 +114,12 @@ HB: AddAG.sort is a canonical projection
 HB: AddAG.sort has the following canonical values:
     - Z 
     - Ring.sort (from "./examples/demo1/hierarchy_5.v", line 194)
+    - Ring_of_TYPE.sort (from "./examples/demo1/hierarchy_5.v", line 165)
+    - Ring_of_AddComoid.sort (from "./examples/demo1/hierarchy_5.v", line 142)
+    - Ring_of_AddAG.sort (from "./examples/demo1/hierarchy_5.v", line 108)
+    - AddAG_of_TYPE.sort (from "./examples/demo1/hierarchy_5.v", line 51)
+    - AddAG_of_AddComoid.sort (from "./examples/demo1/hierarchy_5.v", line 44)
+    - @eta 
 
 HB: AddAG.sort is a coercion from hierarchy_5.AddAG to Sortclass
     (from "./examples/demo1/hierarchy_5.v", line 72)

--- a/tests/about.v.out
+++ b/tests/about.v.out
@@ -15,7 +15,13 @@ HB: AddMonoid_of_TYPE.Build is a factory constructor
 HB: AddMonoid_of_TYPE.Build requires its subject to be already equipped with:
 HB: AddMonoid_of_TYPE.Build provides the following mixins:
     - hierarchy_5.AddMonoid_of_TYPE
-HB: arguments: AddMonoid_of_TYPE.Build T zero add addrA add0r addr0
+HB: arguments: AddMonoid_of_TYPE.Build S zero add addrA add0r addr0
+    - S : Type
+    - zero : AddMonoid.sort S
+    - add : S -> S -> S
+    - addrA : associative add
+    - add0r : left_id 0%G add
+    - addr0 : right_id 0%G add
 
 HB: AddAG.type is a structure (from "./examples/demo1/hierarchy_5.v", line 72)
 HB: AddAG.type characterizing operations and axioms are:
@@ -81,7 +87,15 @@ HB: Ring_of_AddAG.Build requires its subject to be already equipped with:
     - hierarchy_5.AddAG_of_AddComoid
 HB: Ring_of_AddAG.Build provides the following mixins:
     - hierarchy_5.BiNearRing_of_AddMonoid
-HB: arguments: Ring_of_AddAG.Build T [one] [mul] mulrA mulr1 mul1r mulrDl mulrDr
+HB: arguments: Ring_of_AddAG.Build A [one] [mul] mulrA mulr1 mul1r mulrDl mulrDr
+    - A : Type
+    - one : A
+    - mul : A -> A -> A
+    - mulrA : associative mul
+    - mulr1 : left_id one mul
+    - mul1r : right_id one mul
+    - mulrDl : left_distributive mul add
+    - mulrDr : right_distributive mul add
 Doc: Builds a Ring from an Abelian Group: the absorbing properties mul0r and
      mul0r are derived from addrC and the other ring axioms, following a proof
      of Hankel (Gerhard Betsch. On the beginnings and development of near-ring
@@ -131,4 +145,4 @@ HB: hierarchy_5_Ring__to__hierarchy_5_SemiRing is a coercion from
 HB: todo HB.about for builder from hierarchy_5.Ring_of_AddAG to 
 hierarchy_5.BiNearRing_of_AddMonoid
 HB: synthesized in file 
-File "./tests/about.v", line 3, column 165, characters 118-242:
+File "./tests/about.v", line 3, column 165, characters 125-249:

--- a/tests/compress_coe.v.out
+++ b/tests/compress_coe.v.out
@@ -4,9 +4,9 @@ fun D D' : D.type =>
   D.sort := D.sort D * D.sort D';
   D.class :=
     {|
-      D.compress_coe_hasA_mixin := HB_unnamed_mixin_16 D D';
-      D.compress_coe_hasB_mixin := HB_unnamed_mixin_17 D D';
-      D.compress_coe_hasC_mixin := HB_unnamed_mixin_18 D D';
+      D.compress_coe_hasA_mixin := HB_unnamed_mixin_66 D D';
+      D.compress_coe_hasB_mixin := HB_unnamed_mixin_67 D D';
+      D.compress_coe_hasC_mixin := HB_unnamed_mixin_68 D D';
       D.compress_coe_hasD_mixin := prodD D D'
     |}
 |}

--- a/tests/compress_coe.v.out
+++ b/tests/compress_coe.v.out
@@ -4,9 +4,15 @@ fun D D' : D.type =>
   D.sort := D.sort D * D.sort D';
   D.class :=
     {|
-      D.compress_coe_hasA_mixin := HB_unnamed_mixin_66 D D';
-      D.compress_coe_hasB_mixin := HB_unnamed_mixin_67 D D';
-      D.compress_coe_hasC_mixin := HB_unnamed_mixin_68 D D';
+      D.compress_coe_hasA_mixin :=
+        prodA (compress_coe_D__to__compress_coe_A D)
+          (compress_coe_D__to__compress_coe_A D');
+      D.compress_coe_hasB_mixin :=
+        prodB tt (compress_coe_D__to__compress_coe_B D)
+          (compress_coe_D__to__compress_coe_B D');
+      D.compress_coe_hasC_mixin :=
+        prodC tt tt (compress_coe_D__to__compress_coe_C D)
+          (compress_coe_D__to__compress_coe_C D');
       D.compress_coe_hasD_mixin := prodD D D'
     |}
 |}

--- a/tests/compress_coe.v.out
+++ b/tests/compress_coe.v.out
@@ -4,15 +4,9 @@ fun D D' : D.type =>
   D.sort := D.sort D * D.sort D';
   D.class :=
     {|
-      D.compress_coe_hasA_mixin :=
-        prodA (compress_coe_D__to__compress_coe_A D)
-          (compress_coe_D__to__compress_coe_A D');
-      D.compress_coe_hasB_mixin :=
-        prodB tt (compress_coe_D__to__compress_coe_B D)
-          (compress_coe_D__to__compress_coe_B D');
-      D.compress_coe_hasC_mixin :=
-        prodC tt tt (compress_coe_D__to__compress_coe_C D)
-          (compress_coe_D__to__compress_coe_C D');
+      D.compress_coe_hasA_mixin := HB_unnamed_mixin_16 D D';
+      D.compress_coe_hasB_mixin := HB_unnamed_mixin_17 D D';
+      D.compress_coe_hasC_mixin := HB_unnamed_mixin_18 D D';
       D.compress_coe_hasD_mixin := prodD D D'
     |}
 |}

--- a/tests/factory_sort.v
+++ b/tests/factory_sort.v
@@ -35,6 +35,36 @@ Qed.
 Goal forall T (a b : T), G.
 Proof.
 move=> T a b.
+pose Ta := hasA.Build _ a.
+pose A : A.type := ltac:(hb_instance T Ta).
+pose Tab := hasB.Build A b.
+pose AB : AB.type := ltac:(hb_instance A Tab).
+exact: P AB.
+Qed.
+
+Goal forall T (a b : T), G.
+Proof.
+move=> T a b.
+pose Ta := hasA.Build _ a.
+HB.pose A : A.type := xpack T Ta.
+pose Tab := hasB.Build A b.
+HB.pose AB : AB.type := xpack A Tab.
+exact: P AB.
+Qed.
+
+Goal forall T (a b : T), G.
+Proof.
+move=> T a b.
+pose Ta := hasA.Build _ a.
+HB.pose A := A.xpack T Ta.
+pose Tab := hasB.Build A b.
+HB.pose AB := AB.xpack A Tab.
+exact: P AB.
+Qed.
+
+Goal forall T (a b : T), G.
+Proof.
+move=> T a b.
 exact: P [the AB.type of hasAB.Build T a b : Type].
 Qed.
 

--- a/tests/factory_sort_tac.v
+++ b/tests/factory_sort_tac.v
@@ -13,7 +13,7 @@ HB.structure Definition AB := {T of hasA T & hasB T}.
 
 HB.factory Record hasAB T := { a : T; b : T }.
 HB.builders Context T of hasAB T.
-Definition xxx := AB.pack T (hasB.Build T b) (hasA.Build T a).
+Definition xxx := AB.xpack T (hasB.Build T b) (hasA.Build T a).
 HB.instance Definition _ := AB.copy T xxx.
 HB.end.
 About hasAB.type.
@@ -38,9 +38,9 @@ Goal forall T (a b : T), G.
 Proof.
 move=> T a b.
 pose Ta := hasA.Build _ a.
-pose A := ltac:(hb_instance A.type T Ta).
+pose A := ltac:(hb_instance_of A.type T Ta).
 pose Tab := hasB.Build A b.
-pose AB := ltac:(hb_instance AB.type A Tab).
+pose AB := ltac:(hb_instance_of AB.type A Tab).
 exact: P AB.
 Qed.
 
@@ -58,9 +58,9 @@ Goal forall T (a b : T), G.
 Proof.
 move=> T a b.
 pose Ta := hasA.Build _ a.
-pose A := A.pack T Ta.
+pose A := A.xpack T Ta.
 pose Tab := hasB.Build A b.
-pose AB := AB.pack A Tab.
+pose AB := AB.xpack A Tab.
 exact: P AB.
 Qed.
 
@@ -72,3 +72,20 @@ exact: P [the AB.type of hasAB.Build T a b : Type].
 Qed.
 
 End test.
+
+HB.mixin Record HasFoo (A : Type) (P : A -> Prop) T := {
+  foo : forall x, P x -> T;
+}.
+HB.structure Definition Foo A P := { T of HasFoo A P T }.
+
+Section test2.
+Variable A : Type.
+Variable P : A -> Prop.
+
+Goal forall T, (forall x, P x -> T) -> True.
+intros T H.
+pose X := Foo.xpack A P T (HasFoo.Build A P T H).
+Check X : Foo.type A P.
+Abort.
+
+End test2.

--- a/tests/factory_sort_tac.v
+++ b/tests/factory_sort_tac.v
@@ -13,7 +13,7 @@ HB.structure Definition AB := {T of hasA T & hasB T}.
 
 HB.factory Record hasAB T := { a : T; b : T }.
 HB.builders Context T of hasAB T.
-Definition xxx := AB.xpack T (hasB.Build T b) (hasA.Build T a).
+Definition xxx := AB.pack T (hasB.Build T b) (hasA.Build T a).
 HB.instance Definition _ := AB.copy T xxx.
 HB.end.
 About hasAB.type.
@@ -58,17 +58,10 @@ Goal forall T (a b : T), G.
 Proof.
 move=> T a b.
 pose Ta := hasA.Build _ a.
-pose A := A.xpack T Ta.
+pose A := A.pack T Ta.
 pose Tab := hasB.Build A b.
-pose AB := AB.xpack A Tab.
+pose AB := AB.pack A Tab.
 exact: P AB.
-Qed.
-
-
-Goal forall T (a b : T), G.
-Proof.
-move=> T a b.
-exact: P [the AB.type of hasAB.Build T a b : Type].
 Qed.
 
 End test.
@@ -84,7 +77,7 @@ Variable P : A -> Prop.
 
 Goal forall T, (forall x, P x -> T) -> True.
 intros T H.
-pose X := Foo.xpack A P T (HasFoo.Build A P T H).
+pose X := Foo.pack A P T (HasFoo.Build A P T H).
 Check X : Foo.type A P.
 Abort.
 

--- a/tests/factory_sort_tac.v
+++ b/tests/factory_sort_tac.v
@@ -38,9 +38,9 @@ Goal forall T (a b : T), G.
 Proof.
 move=> T a b.
 pose Ta := hasA.Build _ a.
-HB.pose A : A.type := xpack T Ta.
+pose A := ltac:(hb_instance A.type T Ta).
 pose Tab := hasB.Build A b.
-HB.pose AB : AB.type := xpack A Tab.
+pose AB := ltac:(hb_instance AB.type A Tab).
 exact: P AB.
 Qed.
 
@@ -48,11 +48,22 @@ Goal forall T (a b : T), G.
 Proof.
 move=> T a b.
 pose Ta := hasA.Build _ a.
-HB.pose A := A.xpack T Ta.
+pose A : A.type := HB.pack T Ta.
 pose Tab := hasB.Build A b.
-HB.pose AB := AB.xpack A Tab.
+pose AB : AB.type := HB.pack A Tab.
 exact: P AB.
 Qed.
+
+Goal forall T (a b : T), G.
+Proof.
+move=> T a b.
+pose Ta := hasA.Build _ a.
+pose A := A.xpack T Ta.
+pose Tab := hasB.Build A b.
+pose AB := AB.xpack A Tab.
+exact: P AB.
+Qed.
+
 
 Goal forall T (a b : T), G.
 Proof.

--- a/tests/factory_sort_tac.v
+++ b/tests/factory_sort_tac.v
@@ -15,7 +15,7 @@ HB.structure Definition AB := {T of hasA T & hasB T}.
 HB.factory Record hasAB T := { a : T; b : T * T }.
 HB.builders Context T of hasAB T.
 
-Definition xxx := AB.pack T (hasB.Build T b) (hasA.Build T a).
+Definition xxx := HB.pack_for AB.type T (hasB.Build T b) (hasA.Build T a).
 HB.instance Definition _ := AB.copy T xxx.
 HB.end.
 About hasAB.type.
@@ -60,43 +60,43 @@ Goal forall T (a b : T), G.
 Proof.
 move=> T a b.
 pose Ta := hasA.Build _ a.
-pose A := A.pack T Ta.
+pose A := HB.pack_for A.type T Ta.
 pose Tab := hasB.Build A (b,b).
-pose AB := AB.pack A Tab.
+pose AB := HB.pack_for AB.type A Tab.
 exact: 
 P AB.
 Qed.
 
 Check forall T : AB.type,
-  let x := AB.pack T in
+  let x := HB.pack_for AB.type T in
   x.
 
 Goal forall T (a b : T), G.
 Proof.
 move=> T a b.
 
-unshelve epose (A := A.pack T (_ : hasA T)).
+unshelve epose (A := HB.pack_for A.type T (_ : hasA T)).
   by exact: (hasA.Build _ a).
 Check A : A.type.
 
-unshelve epose (A1 := A.pack T (hasA.Build T _)).
+unshelve epose (A1 := HB.pack_for A.type T (hasA.Build T _)).
   by exact: a.
 Check A : A.type.
 
-pose AB1 := AB.pack A (_ : hasB _).
+pose AB1 := HB.pack_for AB.type A (_ : hasB _).
 Check AB1 : hasB A -> AB.type.
 
-have [:Bm] @AB2 := AB.pack A (Bm : hasB A).
+have [:Bm] @AB2 := HB.pack_for AB.type A (Bm : hasB A).
   by exact: (hasB.Build _ (b,b)).
 Check Bm : hasB A.
 Check AB2 : AB.type.
 
-have [:pB] @AB3 := AB.pack A (hasB.Build A pB).
+have [:pB] @AB3 := HB.pack_for AB.type A (hasB.Build A pB).
   by exact: (b,b).
 Check pB : T * T.
 Check AB3 : AB.type.
 
-have [:pA pB'] @AB4 := AB.pack T (hasAB.Build A pA pB').
+have [:pA pB'] @AB4 := HB.pack_for AB.type T (hasAB.Build A pA pB').
   by exact: a.
   by exact: (b,b).
 
@@ -116,7 +116,7 @@ Variable P : A -> Prop.
 
 Goal forall T, (forall x, P x -> T) -> True.
 intros T H.
-pose X := Foo.pack A P T (HasFoo.Build A P T H).
+pose X := HB.pack_for Foo.type A P T (HasFoo.Build A P T H).
 Check X : Foo.type A P.
 Abort.
 

--- a/tests/factory_sort_tac.v
+++ b/tests/factory_sort_tac.v
@@ -6,13 +6,13 @@ From HB Require Import structures.
 About hasA.type.
 HB.structure Definition A := {T of hasA T}.
 
-HB.mixin Record hasB T := { b : T }.
+HB.mixin Record hasB T := { b : T * T }.
 About hasB.type.
 HB.structure Definition B := {T of hasB T}.
 
 HB.structure Definition AB := {T of hasA T & hasB T}.
 
-HB.factory Record hasAB T := { a : T; b : T }.
+HB.factory Record hasAB T := { a : T; b : T * T }.
 HB.builders Context T of hasAB T.
 Definition xxx := AB.pack T (hasB.Build T b) (hasA.Build T a).
 HB.instance Definition _ := AB.copy T xxx.
@@ -29,9 +29,9 @@ Goal forall T (a b : T), G.
 Proof.
 move=> T a b.
 pose Ta := hasA.Build _ a.
-pose A := ltac:(elpi hb_pack_for (A.type) (T) (Ta)).
-pose Tab := hasB.Build A b.
-pose AB : AB.type := ltac:(elpi hb_pack (A) (Tab)).
+pose A := ltac:(elpi HB.pack_for (A.type) (T) (Ta)).
+pose Tab := hasB.Build A (b,b).
+pose AB : AB.type := ltac:(elpi HB.pack (A) (Tab)).
 exact: P AB.
 Qed.
 
@@ -40,7 +40,7 @@ Proof.
 move=> T a b.
 pose Ta := hasA.Build _ a.
 pose A := HB.pack_for A.type T Ta.
-pose Tab := hasB.Build A b.
+pose Tab := hasB.Build A (b,b).
 pose AB := HB.pack_for AB.type A Tab.
 exact: P AB.
 Qed.
@@ -50,7 +50,7 @@ Proof.
 move=> T a b.
 pose Ta := hasA.Build _ a.
 pose A : A.type := HB.pack T Ta.
-pose Tab := hasB.Build A b.
+pose Tab := hasB.Build A (b,b).
 pose AB : AB.type := HB.pack A Tab.
 exact: P AB.
 Qed.
@@ -60,9 +60,42 @@ Proof.
 move=> T a b.
 pose Ta := hasA.Build _ a.
 pose A := A.pack T Ta.
-pose Tab := hasB.Build A b.
+pose Tab := hasB.Build A (b,b).
 pose AB := AB.pack A Tab.
-exact: P AB.
+exact: 
+P AB.
+Qed.
+
+Goal forall T (a b : T), G.
+Proof.
+move=> T a b.
+
+unshelve epose (A := A.pack T (_ : hasA T)).
+  by exact: (hasA.Build _ a).
+Check A : A.type.
+
+unshelve epose (A1 := A.pack T (hasA.Build T _)).
+  by exact: a.
+Check A : A.type.
+
+pose AB1 := AB.pack A (_ : hasB _).
+Check AB1 : hasB A -> AB.type.
+
+have [:Bm] @AB2 := AB.pack A (Bm : hasB A).
+  by exact: (hasB.Build _ (b,b)).
+Check Bm : hasB A.
+Check AB2 : AB.type.
+
+have [:pB] @AB3 := AB.pack A (hasB.Build A pB).
+  by exact: (b,b).
+Check pB : T * T.
+Check AB3 : AB.type.
+
+have [:pA pB'] @AB4 := AB.pack T (hasAB.Build A pA pB').
+  by exact: a.
+  by exact: (b,b).
+
+exact: P AB4.
 Qed.
 
 End test.

--- a/tests/factory_sort_tac.v
+++ b/tests/factory_sort_tac.v
@@ -1,4 +1,5 @@
 Require Import ssreflect ssrfun ssrbool.
+From elpi Require Import elpi.
 From HB Require Import structures.
 
 #[verbose] HB.mixin Record hasA T := { a : T }.
@@ -28,9 +29,9 @@ Goal forall T (a b : T), G.
 Proof.
 move=> T a b.
 pose Ta := hasA.Build _ a.
-pose A : A.type := ltac:(hb_instance T Ta).
+pose A := ltac:(elpi hb_pack_for (A.type) (T) (Ta)).
 pose Tab := hasB.Build A b.
-pose AB : AB.type := ltac:(hb_instance A Tab).
+pose AB : AB.type := ltac:(elpi hb_pack (A) (Tab)).
 exact: P AB.
 Qed.
 
@@ -38,9 +39,9 @@ Goal forall T (a b : T), G.
 Proof.
 move=> T a b.
 pose Ta := hasA.Build _ a.
-pose A := ltac:(hb_instance_of A.type T Ta).
+pose A := HB.pack_for A.type T Ta.
 pose Tab := hasB.Build A b.
-pose AB := ltac:(hb_instance_of AB.type A Tab).
+pose AB := HB.pack_for AB.type A Tab.
 exact: P AB.
 Qed.
 

--- a/tests/factory_sort_tac.v
+++ b/tests/factory_sort_tac.v
@@ -28,8 +28,30 @@ Goal forall T (a b : T), G.
 Proof.
 move=> T a b.
 pose Ta := hasA.Build _ a.
-pose Tab := hasB.Build Ta b.
-exact: P (AB.pack T Tab).
+pose A : A.type := ltac:(hb_instance T Ta).
+pose Tab := hasB.Build A b.
+pose AB : AB.type := ltac:(hb_instance A Tab).
+exact: P AB.
+Qed.
+
+Goal forall T (a b : T), G.
+Proof.
+move=> T a b.
+pose Ta := hasA.Build _ a.
+HB.pose A : A.type := xpack T Ta.
+pose Tab := hasB.Build A b.
+HB.pose AB : AB.type := xpack A Tab.
+exact: P AB.
+Qed.
+
+Goal forall T (a b : T), G.
+Proof.
+move=> T a b.
+pose Ta := hasA.Build _ a.
+HB.pose A := A.xpack T Ta.
+pose Tab := hasB.Build A b.
+HB.pose AB := AB.xpack A Tab.
+exact: P AB.
 Qed.
 
 Goal forall T (a b : T), G.

--- a/tests/factory_sort_tac.v
+++ b/tests/factory_sort_tac.v
@@ -14,6 +14,7 @@ HB.structure Definition AB := {T of hasA T & hasB T}.
 
 HB.factory Record hasAB T := { a : T; b : T * T }.
 HB.builders Context T of hasAB T.
+
 Definition xxx := AB.pack T (hasB.Build T b) (hasA.Build T a).
 HB.instance Definition _ := AB.copy T xxx.
 HB.end.
@@ -65,6 +66,10 @@ pose AB := AB.pack A Tab.
 exact: 
 P AB.
 Qed.
+
+Check forall T : AB.type,
+  let x := AB.pack T in
+  x.
 
 Goal forall T (a b : T), G.
 Proof.

--- a/tests/factory_sort_tac.v
+++ b/tests/factory_sort_tac.v
@@ -13,8 +13,8 @@ HB.structure Definition AB := {T of hasA T & hasB T}.
 
 HB.factory Record hasAB T := { a : T; b : T }.
 HB.builders Context T of hasAB T.
-HB.instance Definition _ := AB.copy T
-  (AB.pack T (hasB.Build (hasA.Build T a) b)).
+Definition xxx := AB.pack T (hasB.Build T b) (hasA.Build T a).
+HB.instance Definition _ := AB.copy T xxx.
 HB.end.
 About hasAB.type.
 
@@ -58,9 +58,9 @@ Goal forall T (a b : T), G.
 Proof.
 move=> T a b.
 pose Ta := hasA.Build _ a.
-pose A := A.xpack T Ta.
+pose A := A.pack T Ta.
 pose Tab := hasB.Build A b.
-pose AB := AB.xpack A Tab.
+pose AB := AB.pack A Tab.
 exact: P AB.
 Qed.
 

--- a/tests/factory_sort_tac.v
+++ b/tests/factory_sort_tac.v
@@ -9,13 +9,13 @@ HB.structure Definition A := {T of hasA T}.
 HB.mixin Record hasB T := { b : T * T }.
 About hasB.type.
 HB.structure Definition B := {T of hasB T}.
-
+#[short(pack="AB.pack")]
 HB.structure Definition AB := {T of hasA T & hasB T}.
 
 HB.factory Record hasAB T := { a : T; b : T * T }.
 HB.builders Context T of hasAB T.
 
-Definition xxx := AB.pack T (hasB.Build T b) (hasA.Build T a).
+Definition xxx := HB.pack_for AB.type T (hasB.Build T b) (hasA.Build T a).
 HB.instance Definition _ := AB.copy T xxx.
 HB.end.
 About hasAB.type.
@@ -56,16 +56,6 @@ pose AB : AB.type := HB.pack A Tab.
 exact: P AB.
 Qed.
 
-Goal forall T (a b : T), G.
-Proof.
-move=> T a b.
-pose Ta := hasA.Build _ a.
-pose A := A.pack T Ta.
-pose Tab := hasB.Build A (b,b).
-pose AB := AB.pack A Tab.
-exact: 
-P AB.
-Qed.
 
 Check forall T : AB.type,
   let x := AB.pack T in
@@ -75,11 +65,11 @@ Goal forall T (a b : T), G.
 Proof.
 move=> T a b.
 
-unshelve epose (A := A.pack T (_ : hasA T)).
+unshelve epose (A := HB.pack_for A.type T (_ : hasA T)).
   by exact: (hasA.Build _ a).
 Check A : A.type.
 
-unshelve epose (A1 := A.pack T (hasA.Build T _)).
+unshelve epose (A1 := HB.pack_for A.type T (hasA.Build T _)).
   by exact: a.
 Check A : A.type.
 
@@ -108,6 +98,7 @@ End test.
 HB.mixin Record HasFoo (A : Type) (P : A -> Prop) T := {
   foo : forall x, P x -> T;
 }.
+#[short(pack="Foo.pack")]
 HB.structure Definition Foo A P := { T of HasFoo A P T }.
 
 Section test2.
@@ -116,7 +107,7 @@ Variable P : A -> Prop.
 
 Goal forall T, (forall x, P x -> T) -> True.
 intros T H.
-pose X := Foo.pack A P T (HasFoo.Build A P T H).
+pose X := Foo.pack T (HasFoo.Build A P T H).
 Check X : Foo.type A P.
 Abort.
 

--- a/tests/factory_sort_tac.v
+++ b/tests/factory_sort_tac.v
@@ -15,7 +15,7 @@ HB.structure Definition AB := {T of hasA T & hasB T}.
 HB.factory Record hasAB T := { a : T; b : T * T }.
 HB.builders Context T of hasAB T.
 
-Definition xxx := HB.pack_for AB.type T (hasB.Build T b) (hasA.Build T a).
+Definition xxx := AB.pack T (hasB.Build T b) (hasA.Build T a).
 HB.instance Definition _ := AB.copy T xxx.
 HB.end.
 About hasAB.type.
@@ -60,43 +60,43 @@ Goal forall T (a b : T), G.
 Proof.
 move=> T a b.
 pose Ta := hasA.Build _ a.
-pose A := HB.pack_for A.type T Ta.
+pose A := A.pack T Ta.
 pose Tab := hasB.Build A (b,b).
-pose AB := HB.pack_for AB.type A Tab.
+pose AB := AB.pack A Tab.
 exact: 
 P AB.
 Qed.
 
 Check forall T : AB.type,
-  let x := HB.pack_for AB.type T in
+  let x := AB.pack T in
   x.
 
 Goal forall T (a b : T), G.
 Proof.
 move=> T a b.
 
-unshelve epose (A := HB.pack_for A.type T (_ : hasA T)).
+unshelve epose (A := A.pack T (_ : hasA T)).
   by exact: (hasA.Build _ a).
 Check A : A.type.
 
-unshelve epose (A1 := HB.pack_for A.type T (hasA.Build T _)).
+unshelve epose (A1 := A.pack T (hasA.Build T _)).
   by exact: a.
 Check A : A.type.
 
-pose AB1 := HB.pack_for AB.type A (_ : hasB _).
+pose AB1 := AB.pack A (_ : hasB _).
 Check AB1 : hasB A -> AB.type.
 
-have [:Bm] @AB2 := HB.pack_for AB.type A (Bm : hasB A).
+have [:Bm] @AB2 := AB.pack A (Bm : hasB A).
   by exact: (hasB.Build _ (b,b)).
 Check Bm : hasB A.
 Check AB2 : AB.type.
 
-have [:pB] @AB3 := HB.pack_for AB.type A (hasB.Build A pB).
+have [:pB] @AB3 := AB.pack A (hasB.Build A pB).
   by exact: (b,b).
 Check pB : T * T.
 Check AB3 : AB.type.
 
-have [:pA pB'] @AB4 := HB.pack_for AB.type T (hasAB.Build A pA pB').
+have [:pA pB'] @AB4 := AB.pack T (hasAB.Build A pA pB').
   by exact: a.
   by exact: (b,b).
 
@@ -116,7 +116,7 @@ Variable P : A -> Prop.
 
 Goal forall T, (forall x, P x -> T) -> True.
 intros T H.
-pose X := HB.pack_for Foo.type A P T (HasFoo.Build A P T H).
+pose X := Foo.pack A P T (HasFoo.Build A P T H).
 Check X : Foo.type A P.
 Abort.
 

--- a/tests/fix_loop.v
+++ b/tests/fix_loop.v
@@ -1,0 +1,4 @@
+From HB Require Import structures.
+
+HB.mixin Record M A := { x: nat }.
+#[primitive_class] HB.structure Definition S := { A of M A }.

--- a/tests/short.v
+++ b/tests/short.v
@@ -35,10 +35,4 @@ pose Tb := hasB.Build T b.
 exact: P (ABType T Ta Tb).
 Qed.
 
-Goal forall T (a b : T), G.
-Proof.
-move=> T a b.
-exact: P [the abType of hasAB.Build T a b : Type].
-Qed.
-
 End test.

--- a/tests/short.v
+++ b/tests/short.v
@@ -16,7 +16,7 @@ HB.structure Definition AB := {T of hasA T & hasB T}.
 
 HB.factory Record hasAB T := { a : T; b : T }.
 HB.builders Context T of hasAB T.
-Definition xxx := ABType T (hasB.Build T b) (hasA.Build T a).
+Definition xxx := HB.pack_for AB.type T (hasB.Build T b) (hasA.Build T a).
 HB.instance Definition _ := AB.copy T xxx.
 HB.end.
 About hasAB.type.
@@ -32,7 +32,7 @@ Proof.
 move=> T a b.
 pose Ta := hasA.Build T a.
 pose Tb := hasB.Build T b.
-exact: P (ABType T Ta Tb).
+exact: P (HB.pack T Ta Tb).
 Qed.
 
 End test.

--- a/tests/short.v
+++ b/tests/short.v
@@ -16,7 +16,7 @@ HB.structure Definition AB := {T of hasA T & hasB T}.
 
 HB.factory Record hasAB T := { a : T; b : T }.
 HB.builders Context T of hasAB T.
-Definition xxx := HB.pack_for AB.type T (hasB.Build T b) (hasA.Build T a).
+Definition xxx := ABType T (hasB.Build T b) (hasA.Build T a).
 HB.instance Definition _ := AB.copy T xxx.
 HB.end.
 About hasAB.type.
@@ -32,7 +32,7 @@ Proof.
 move=> T a b.
 pose Ta := hasA.Build T a.
 pose Tb := hasB.Build T b.
-exact: P (HB.pack T Ta Tb).
+exact: P (ABType T Ta Tb).
 Qed.
 
 End test.

--- a/tests/short.v
+++ b/tests/short.v
@@ -16,8 +16,8 @@ HB.structure Definition AB := {T of hasA T & hasB T}.
 
 HB.factory Record hasAB T := { a : T; b : T }.
 HB.builders Context T of hasAB T.
-HB.instance Definition _ := AB.copy T
-  (ABType T (hasB.Build (hasA.Build T a) b)).
+Definition xxx := ABType T (hasB.Build T b) (hasA.Build T a).
+HB.instance Definition _ := AB.copy T xxx.
 HB.end.
 About hasAB.type.
 
@@ -30,9 +30,9 @@ Variables (G : Prop) (P : AB.type -> G).
 Goal forall T (a b : T), G.
 Proof.
 move=> T a b.
-pose Ta := hasA.Build _ a.
-pose Tab := hasB.Build Ta b.
-exact: P (ABType T Tab).
+pose Ta := hasA.Build T a.
+pose Tb := hasB.Build T b.
+exact: P (ABType T Ta Tb).
 Qed.
 
 Goal forall T (a b : T), G.


### PR DESCRIPTION
This should make Factory.sort unnecessary and speed up compilation.

We use xpack to avoid conflicts.
This now requires https://github.com/LPCIC/coq-elpi/pull/257
The status is the following:
- [x] Global `HB.pack` tactic which can be used for any structure (but no planB), works as `pose X : S.type := HB.pack T F`
- [x] `Structure.xpack` generated for any structure. Note that it's not a real qualification, it's a global notation; works as `pose X := S.xpack T F`
- [x] `short(pack = "name")`
- [x] logging to fix planB (may require patching `coq.hb` since the loc are right, but the patch is not line based, but rather char based)

Fix #253
