### PR TITLE
Adapt to coq PR #14596 which let Arguments displaying all names in About/Print

### DIFF
--- a/tests/compress_coe.v.out
+++ b/tests/compress_coe.v.out
@@ -17,3 +17,5 @@ fun D D' : D.type =>
     |}
 |}
      : D.type -> D.type -> D.type
+
+Arguments Datatypes_prod__canonical__compress_coe_D D D'


### PR DESCRIPTION
Hi, Coq's PR coq/coq#14596 grants wish coq/coq#13830 and let `Arguments` display all names in `About`/`Print`. This PR adapts the hierarchy builder tests so that it continues to be consistent with Coq's CI.

To be merged synchronously with coq/coq#14596.