### PR TITLE
adapt to coq-elpi#360

### DIFF
--- a/structures.v
+++ b/structures.v
@@ -226,6 +226,7 @@ compress X X.
     or inductive was generated.
 *)
 
+#[arguments(raw)]
 Elpi Command HB.locate.
 Elpi Accumulate Db hb.db.
 Elpi Accumulate lp:{{
@@ -256,6 +257,7 @@ Elpi Export HB.locate.
     - canonical value, eg Z, prod, ...
 *)
 
+#[arguments(raw)]
 Elpi Command HB.about.
 Elpi Accumulate File "HB/common/stdpp.elpi".
 Elpi Accumulate File "HB/common/utils.elpi".
@@ -281,6 +283,7 @@ Elpi Export HB.about.
 
 *)
 
+#[arguments(raw)]
 Elpi Command HB.status.
 Elpi Accumulate File "HB/common/stdpp.elpi".
 Elpi Accumulate File "HB/common/utils.elpi".
@@ -306,6 +309,7 @@ tred file.dot | xdot -
     to visualize file.dot
 *)
 
+#[arguments(raw)]
 Elpi Command HB.graph.
 Elpi Accumulate File "HB/common/stdpp.elpi".
 Elpi Accumulate File "HB/common/utils.elpi".
@@ -351,6 +355,7 @@ HB.mixin Record MixinName T of Factory1 T & … & FactoryN T := {
 
 *)
 
+#[arguments(raw)]
 Elpi Command HB.mixin.
 Elpi Accumulate File "HB/common/stdpp.elpi".
 Elpi Accumulate File "HB/common/utils.elpi".
@@ -512,6 +517,7 @@ HB.structure Definition StructureName params :=
   - [#[verbose]] for a verbose output.
 *)
 
+#[arguments(raw)]
 Elpi Command HB.structure.
 Elpi Accumulate File "HB/common/stdpp.elpi".
 Elpi Accumulate File "HB/common/utils.elpi".
@@ -558,6 +564,7 @@ HB.instance Definition N Params := Factory.Build Params T …
     - [#[verbose]] for a verbose output.
 *)
 
+#[arguments(raw)]
 Elpi Command HB.instance.
 Elpi Accumulate File "HB/common/stdpp.elpi".
 Elpi Accumulate File "HB/common/utils.elpi".
@@ -587,6 +594,7 @@ Elpi Export HB.instance.
 
 (** [HB.factory] declares a factory. It has the same syntax of [HB.mixin] *)
 
+#[arguments(raw)]
 Elpi Command HB.factory.
 Elpi Accumulate File "HB/common/stdpp.elpi".
 Elpi Accumulate File "HB/common/utils.elpi".
@@ -645,6 +653,7 @@ HB.end.
     - [#[verbose]] for a verbose output.
 *)
 
+#[arguments(raw)]
 Elpi Command HB.builders.
 Elpi Accumulate File "HB/common/stdpp.elpi".
 Elpi Accumulate File "HB/common/utils.elpi".
@@ -667,6 +676,7 @@ Elpi Typecheck.
 Elpi Export HB.builders.
 
 
+#[arguments(raw)]
 Elpi Command HB.end.
 Elpi Accumulate File "HB/common/stdpp.elpi".
 Elpi Accumulate File "HB/common/utils.elpi".
@@ -717,6 +727,7 @@ Export Algebra.Exports.
 
 *)
 
+#[arguments(raw)]
 Elpi Command HB.export.
 Elpi Accumulate File "HB/common/stdpp.elpi".
 Elpi Accumulate File "HB/common/utils.elpi".
@@ -741,6 +752,7 @@ Elpi Export HB.export.
    It optionally takes the name of a module or a component of the current module path
    (a module which is not closed yet) *)
 
+#[arguments(raw)]
 Elpi Command HB.reexport.
 Elpi Accumulate File "HB/common/stdpp.elpi".
 Elpi Accumulate File "HB/common/utils.elpi".
@@ -831,6 +843,7 @@ HB.instance Definition _ : Ml ... T := ml.
 
 *)
 
+#[arguments(raw)]
 Elpi Command HB.declare.
 Elpi Accumulate File "HB/common/stdpp.elpi".
 Elpi Accumulate File "HB/common/utils.elpi".
@@ -864,6 +877,7 @@ Elpi Export HB.declare.
     that skips the action on Coq version matches rex. It also understands the
     [#[fail]] attribute. *)
 
+#[arguments(raw)]
 Elpi Command HB.check.
 Elpi Accumulate Db hb.db.
 Elpi Accumulate File "HB/common/stdpp.elpi".


### PR DESCRIPTION
This PR makes HB compatible with Coq 8.16, and 8.15 (with coq-elpi 1.14.x).
It breaks compat with older Coq.
It is already merged in coq-master (which is used by to-become 8.16).