### PR TITLE
A few performance improvements

### DIFF
--- a/HB/about.elpi
+++ b/HB/about.elpi
@@ -192,8 +192,10 @@ main-structure S Class Structure MLwP :-
     std.findall (exported-op m P O) OPS,
     std.map OPS (c\out\ sigma p\ c = exported-op m p out) r) OPLL,
   std.flatten OPLL Operations,
-  std.map {std.findall (sub-class Class C_)} (x\r\ x = sub-class Class r) SubClasses,
-  std.map {std.findall (sub-class C_ Class)} (x\r\ x = sub-class r Class) SuperClasses,
+  std.map {std.findall (sub-class Class CS_ CoeS_ NS_)}
+    (x\r\ x = sub-class Class r _ _) SubClasses,
+  std.map {std.findall (sub-class Cs_ Class Coes_ Ns_)}
+    (x\r\ x = sub-class r Class _ _) SuperClasses,
   % format
   PpOrigin = box (hov 4) [
     str "HB: ", str S, str " is a structure", spc,

--- a/HB/common/compat_acc_clauses_816.elpi
+++ b/HB/common/compat_acc_clauses_816.elpi
@@ -1,0 +1,2 @@
+pred acc-clauses i:scope, i:list prop.
+acc-clauses Scope CL :- std.forall CL (acc-clause Scope).

--- a/HB/common/compat_acc_clauses_all.elpi
+++ b/HB/common/compat_acc_clauses_all.elpi
@@ -1,0 +1,2 @@
+pred acc-clauses i:scope, i:list prop.
+acc-clauses Scope CL :- coq.elpi.accumulate-clauses Scope "hb.db" {std.map CL (c\r\ r = clause _ _ c)}.

--- a/HB/common/database.elpi
+++ b/HB/common/database.elpi
@@ -155,10 +155,10 @@ toposort-proj.acc Proj ES Acc [A|In] Out :- std.do![
 
 % Classes can be topologically sorted according to the subclass relation
 pred toposort-classes.mk-class-edge i:prop, o:pair classname classname.
-toposort-classes.mk-class-edge (sub-class C1 C2) (pr C2 C1).
+toposort-classes.mk-class-edge (sub-class C1 C2 _ _) (pr C2 C1).
 pred toposort-classes i:list classname, o:list classname.
 toposort-classes In Out :- std.do! [
-  std.findall (sub-class C1_ C2_) SubClasses,
+  std.findall (sub-class C1_ C2_ _ _) SubClasses,
   std.map SubClasses toposort-classes.mk-class-edge ES,
   std.toposort ES In Out,
 ].

--- a/HB/common/log.elpi
+++ b/HB/common/log.elpi
@@ -181,14 +181,6 @@ log.coq.CS.declare-instance C  :- std.do! [
   log.private.log-vernac (log.private.coq.vernac.canonical Name Local),
 ].
 
-% Since "accumulate" is a keyword we can't use it as a predicate name
-% in the namespace, so we just define it here with the full name
-pred log.coq.env.accumulate i:scope, i:string, i:clause.
-log.coq.env.accumulate S DB CL :- std.do! [
-  coq.elpi.accumulate S DB CL,
-  if-verbose (log.private.log-vernac (log.private.coq.vernac.comment CL)),
-].
-
 pred log.coq.check i:term, o:term, o:term, o:diagnostic.
 log.coq.check Skel Ty T D :- std.do! [
   coq.elaborate-skeleton Skel Ty T D,

--- a/HB/common/synthesis.elpi
+++ b/HB/common/synthesis.elpi
@@ -191,8 +191,21 @@ mixin-for T M MICompressed :- mixin-src T M Tm, !, std.do! [
   compress-coercion-paths MI MICompressed,
 ].
 
+pred drop i:int, i:list A, o:list A.
+drop 0 L L :- !.
+drop N [_|XS] L :- !, N1 is N - 1, drop N1 XS L.
+
 pred compress-copy o:term, o:term.
-compress-copy X Y :- compress X Y, !.
+compress-copy (app [global (const C) | L]) R :-
+  sub-class C2 C3 C NparamsC,
+  drop NparamsC L [app [global (const C') | L']],
+  sub-class C1 C2 C' NparamsC',
+  drop NparamsC' L' L'',
+  sub-class C1 C3 C'' NparamsC'',
+  std.append {coq.mk-n-holes NparamsC''} L'' HL'',
+  CHL'' = app [global (const C'') | HL''],
+  coq.typecheck CHL'' _ ok, !,
+  compress-copy CHL'' R.
 compress-copy (app L) (app L1) :- !, std.map L compress-copy L1.
 compress-copy X X.
 

--- a/HB/common/utils.elpi
+++ b/HB/common/utils.elpi
@@ -74,8 +74,11 @@ with-locality P :-
 pred acc-clause i:scope, i:prop.
 acc-clause Scope C :- coq.elpi.accumulate Scope "hb.db" (clause _ _ C).
 
+/* Uncomment and remove HB/common/compat_acc_clauses_*.elpi once requiring coq-elpi >= 1.18.0,
+   which implies Coq >= 8.17
 pred acc-clauses i:scope, i:list prop.
-acc-clauses Scope CL :- std.forall CL (acc-clause Scope).
+acc-clauses Scope CL :- coq.elpi.accumulate-clauses Scope "hb.db" {std.map CL (c\r\ r = clause _ _ c)}.
+*/
 
 pred save-docstring.
 save-docstring :-

--- a/HB/context.elpi
+++ b/HB/context.elpi
@@ -39,7 +39,7 @@ declare.mixins TheType TheParamsSection MLwPRaw MLwP MSL CL :-  std.do! [
   std.map TheParamsSection triple_2 TheParams,
   apply-w-params MLwPRaw TheParams TheType MLwAllArgsRaw,
   std.fold MLwAllArgsRaw (triple [] [] []) (private.postulate-mixin TheType) (triple CL MSL MLwPRev),
-  std.forall CL (cs\ acc-clause current (local-canonical cs)),
+  acc-clauses current {std.map CL (cs\r\ r = local-canonical cs)},
   std.rev MLwPRev MLwPSection,
   build-list-w-params TheParamsSection TheType MLwPSection MLwP,
   acc-clauses current MSL,

--- a/HB/structure.elpi
+++ b/HB/structure.elpi
@@ -360,8 +360,6 @@ pred declare-coercion i:term, i:term, i:class, i:class.
 declare-coercion SortProjection ClassProjection
     (class FC StructureF FMLwP) (class TC StructureT TMLwP) :- std.do! [
 
-  acc-clause current (sub-class FC TC),
-
   gref->modname StructureF 2 "_" ModNameF,
   gref->modname StructureT 2 "_" ModNameT,
   CName is ModNameF ^ "_class__to__" ^ ModNameT ^ "_class",
@@ -393,40 +391,9 @@ declare-coercion SortProjection ClassProjection
 
   log.coq.CS.declare-instance SC,
 
-  if-verbose (coq.say {header} "declare coercion path compression rules"),
-
-  findall-classes All,
-  CurrentTgtClass = (class TC StructureT TMLwP),
-  std.filter All (sub-class? CurrentTgtClass) AllTgtSuper,
-  std.map AllTgtSuper class_structure AllTgtSuperStructures,
-
-  mk-compression-clauses StructureF StructureT AllTgtSuperStructures AllCompressionClauses,
-  acc-clauses current AllCompressionClauses,
+  w-params.nparams FMLwP NparamsSC,
+  acc-clause current (sub-class FC TC SC NparamsSC)
 ].
-
-
-pred mk-compression-clauses i:gref, i:gref, i:list gref, o:list prop.
-mk-compression-clauses _ _ [] [].
-mk-compression-clauses StructureF StructureT [StructureE|Rest] Res :- std.do! [
-  std.assert! (coq.coercion.db-for (grefclass StructureF) (grefclass StructureT) [pr C1 Nparams1]) "wrong number of coercions",
-  std.assert! (coq.coercion.db-for (grefclass StructureT) (grefclass StructureE) [pr C2 Nparams2]) "wrong number of coercions",
-  std.assert! (coq.coercion.db-for (grefclass StructureF) (grefclass StructureE) [pr C3 Nparams3]) "wrong number of coercions",
-  coq.mk-app (global C1) {coq.mk-n-holes Nparams1} F,
-  coq.mk-app (global C2) {coq.mk-n-holes Nparams2} G,
-  coq.mk-app (global C3) {coq.mk-n-holes Nparams3} H,
-  RuleSkel = {{ fun x => lp:G (lp:F x) = lp:H x}},
-  std.assert-ok! (coq.elaborate-skeleton RuleSkel _ Rule) "coercion composition fails",
-  (((pi X L\ coq.fold-map X L X [X|L] :- var X, not(std.exists L (same_var X))) => coq.fold-map Rule [] Rule Holes,
-  mk-compression-clause Holes Rule Clause,
-  mk-compression-clauses StructureF StructureT Rest Clauses,
-  Res = [Clause|Clauses]) ; (Res = [])),
-].
-
-pred mk-compression-clause i:list term, i:term, o:prop.
-mk-compression-clause [] (fun _ _ x\ app[_,_,LHS x,RHS x]) (pi x\ C x) :-
-  pi x\ copy (LHS x) (L x), copy (RHS x) (R x), C x = (pi tmp\ compress (L x) (R x)).
-mk-compression-clause [UV|Rest] T (pi v\ R v) :-
-  pi v\ (pi U\ copy U v :- same_var U UV, !) => mk-compression-clause Rest T (R v).
 
 pred join-body i:int, i:int, i:structure, i:term, i:term, i:term, i:term, i:term,
   i:list term, i:name, i:term, i:(term -> A), o:term.

--- a/HB/structure.elpi
+++ b/HB/structure.elpi
@@ -401,7 +401,7 @@ declare-coercion SortProjection ClassProjection
   std.map AllTgtSuper class_structure AllTgtSuperStructures,
 
   mk-compression-clauses StructureF StructureT AllTgtSuperStructures AllCompressionClauses,
-  std.forall AllCompressionClauses (c\ log.coq.env.accumulate current "hb.db" (clause _ _ c)),
+  acc-clauses current AllCompressionClauses,
 ].
 
 

--- a/HB/structure.elpi
+++ b/HB/structure.elpi
@@ -160,36 +160,13 @@ declare Module BSkel Sort :- std.do! [
 
   @global! => log.coq.notation.add-abbreviation "on" 1
     {{fun T => (lp:{{ ClassOfAbbrev_ {{_}} }} : (lp:AppClassHoles T)) }} tt
-    OnAbbrev,
-
-  log.coq.env.begin-module "EtaAndMixinExports" none,
-
-  if (get-option "primitive" tt) true (
-    if-verbose (coq.say {header} "eta expanded instances"),
-    NewClauses => std.do! [
-      w-params.fold MLwP mk-fun
-        (private.mk-hb-eta.on Structure SortProjection OnAbbrev) EtaInstanceBody,
-      w-params.fold MLwP (mk-parameter explicit)
-        (private.mk-hb-eta.arity Structure ClassName SortProjection)
-        EtaInstanceArity,
-      instance.declare-const "_" EtaInstanceBody EtaInstanceArity _
-    ]
-    ),
-
-  % std.flatten {std.map NewMixins mixin->factories} NewFactories,
-  % NewClauses => std.forall NewFactories instance.declare-factory-sort-factory,
-
-  log.coq.env.end-module-name "EtaAndMixinExports" EtaExports,
+    _OnAbbrev,
 
   log.coq.env.end-module-name Module ModulePath,
 
   if-verbose (coq.say {header} "end modules; export" Exports),
 
   export.module {calc (Module ^ ".Exports")} Exports,
-
-  if-verbose (coq.say {header} "export" EtaExports),
-
-  export.module {calc (Module ^ ".EtaAndMixinExports")} EtaExports,
 
   if-verbose (coq.say {header} "exporting operations"),
     ClassAlias => Factories => GRDepsClauses =>
@@ -680,33 +657,5 @@ sigT->list-w-params {{ lib:@hb.sigT _ lp:{{ fun N Ty B }} }} L C :-
   L = w-params.nil ID Ty Rest,
   @pi-decl N Ty t\
     product->triples (B t) (Rest t) C.
-
-pred mk-hb-eta.on i:structure, i:term, i:abbreviation,
-  i:list term, i:name, i:term, i:A, o:term.
-mk-hb-eta.on Structure SortProjection OnAbbrev
-    Params NT _T _ (fun NT Ty Body) :- !, std.do! [
-  coq.mk-app (global Structure) Params Ty,
-  @pi-decl NT Ty s\ sigma Tm\ std.do! [
-    coq.mk-app {{lib:@hb.eta}}
-      [_, {coq.mk-app SortProjection {std.append Params [s]}}]
-      Tm,
-    std.assert-ok! (coq.typecheck Tm _) "HB: eta illtyped",
-    coq.notation.abbreviation OnAbbrev [Tm] (Body s)
-  ]
-].
-
-pred mk-hb-eta.arity i:structure, i:classname, i:term, i:list term,
-  i:name, i:term, i:A, o:arity.
-mk-hb-eta.arity Structure ClassName SortProjection
-    Params NT _T _ Out :- !, std.do! [
-  coq.mk-app (global Structure) Params Ty,
-  (@pi-decl NT Ty s\ sigma Tm\ std.do! [
-    coq.mk-app {{lib:@hb.eta}}
-      [_, {coq.mk-app SortProjection {std.append Params [s]}}] Tm,
-    std.assert-ok! (coq.typecheck Tm _) "HB: eta illtyped",
-    coq.mk-app (global ClassName) {std.append Params [Tm]} (Concl s)
-  ]),
-  Out = parameter {coq.name->id NT} explicit Ty s\ arity (Concl s)
-].
 
 }}

--- a/structures.v
+++ b/structures.v
@@ -278,6 +278,8 @@ Elpi Export HB.locate.
 #[only="8.15.*"] Elpi Accumulate File "HB/common/compat_815.elpi".
 Elpi Accumulate File "HB/common/stdpp.elpi".
 Elpi Accumulate File "HB/common/database.elpi".
+#[skip="8.1[56].*"] Elpi Accumulate File "HB/common/compat_acc_clauses_all.elpi".
+#[only="8.1[56].*"] Elpi Accumulate File "HB/common/compat_acc_clauses_816.elpi".
 Elpi Accumulate File "HB/common/utils.elpi".
 Elpi Accumulate File "HB/common/log.elpi".
 Elpi Accumulate File "HB/about.elpi".
@@ -311,6 +313,8 @@ Elpi Export HB.about.
 #[only="8.15.*"] Elpi Accumulate File "HB/common/compat_815.elpi".
 Elpi Accumulate File "HB/common/stdpp.elpi".
 Elpi Accumulate File "HB/common/database.elpi".
+#[skip="8.1[56].*"] Elpi Accumulate File "HB/common/compat_acc_clauses_all.elpi".
+#[only="8.1[56].*"] Elpi Accumulate File "HB/common/compat_acc_clauses_816.elpi".
 Elpi Accumulate File "HB/common/utils.elpi".
 Elpi Accumulate File "HB/common/log.elpi".
 Elpi Accumulate File "HB/about.elpi".
@@ -352,6 +356,8 @@ Elpi Export HB.howto.
 #[only="8.15.*"] Elpi Accumulate File "HB/common/compat_815.elpi".
 Elpi Accumulate File "HB/common/stdpp.elpi".
 Elpi Accumulate File "HB/common/database.elpi".
+#[skip="8.1[56].*"] Elpi Accumulate File "HB/common/compat_acc_clauses_all.elpi".
+#[only="8.1[56].*"] Elpi Accumulate File "HB/common/compat_acc_clauses_816.elpi".
 Elpi Accumulate File "HB/common/utils.elpi".
 Elpi Accumulate File "HB/status.elpi".
 Elpi Accumulate Db hb.db.
@@ -380,6 +386,8 @@ tred file.dot | xdot -
 #[only="8.15.*"] Elpi Accumulate File "HB/common/compat_815.elpi".
 Elpi Accumulate File "HB/common/stdpp.elpi".
 Elpi Accumulate File "HB/common/database.elpi".
+#[skip="8.1[56].*"] Elpi Accumulate File "HB/common/compat_acc_clauses_all.elpi".
+#[only="8.1[56].*"] Elpi Accumulate File "HB/common/compat_acc_clauses_816.elpi".
 Elpi Accumulate File "HB/common/utils.elpi".
 Elpi Accumulate File "HB/common/log.elpi".
 Elpi Accumulate File "HB/graph.elpi".
@@ -428,6 +436,8 @@ HB.mixin Record MixinName T of Factory1 T & … & FactoryN T := {
 #[only="8.15.*"] Elpi Accumulate File "HB/common/compat_815.elpi".
 Elpi Accumulate File "HB/common/stdpp.elpi".
 Elpi Accumulate File "HB/common/database.elpi".
+#[skip="8.1[56].*"] Elpi Accumulate File "HB/common/compat_acc_clauses_all.elpi".
+#[only="8.1[56].*"] Elpi Accumulate File "HB/common/compat_acc_clauses_816.elpi".
 Elpi Accumulate File "HB/common/utils.elpi".
 Elpi Accumulate File "HB/common/log.elpi".
 Elpi Accumulate File "HB/common/synthesis.elpi".
@@ -490,6 +500,8 @@ Elpi Accumulate Db hb.db.
 #[only="8.15.*"] Elpi Accumulate File "HB/common/compat_815.elpi".
 Elpi Accumulate File "HB/common/stdpp.elpi".
 Elpi Accumulate File "HB/common/database.elpi".
+#[skip="8.1[56].*"] Elpi Accumulate File "HB/common/compat_acc_clauses_all.elpi".
+#[only="8.1[56].*"] Elpi Accumulate File "HB/common/compat_acc_clauses_816.elpi".
 Elpi Accumulate File "HB/common/utils.elpi".
 Elpi Accumulate File "HB/common/log.elpi".
 Elpi Accumulate File "HB/common/synthesis.elpi".
@@ -512,6 +524,8 @@ Elpi Accumulate Db hb.db.
 #[only="8.15.*"] Elpi Accumulate File "HB/common/compat_815.elpi".
 Elpi Accumulate File "HB/common/stdpp.elpi".
 Elpi Accumulate File "HB/common/database.elpi".
+#[skip="8.1[56].*"] Elpi Accumulate File "HB/common/compat_acc_clauses_all.elpi".
+#[only="8.1[56].*"] Elpi Accumulate File "HB/common/compat_acc_clauses_816.elpi".
 Elpi Accumulate File "HB/common/utils.elpi".
 Elpi Accumulate File "HB/common/log.elpi".
 Elpi Accumulate File "HB/common/synthesis.elpi".
@@ -595,6 +609,8 @@ HB.structure Definition StructureName params :=
 #[only="8.15.*"] Elpi Accumulate File "HB/common/compat_815.elpi".
 Elpi Accumulate File "HB/common/stdpp.elpi".
 Elpi Accumulate File "HB/common/database.elpi".
+#[skip="8.1[56].*"] Elpi Accumulate File "HB/common/compat_acc_clauses_all.elpi".
+#[only="8.1[56].*"] Elpi Accumulate File "HB/common/compat_acc_clauses_816.elpi".
 Elpi Accumulate File "HB/common/utils.elpi".
 Elpi Accumulate File "HB/common/log.elpi".
 Elpi Accumulate File "HB/common/synthesis.elpi".
@@ -649,6 +665,8 @@ HB.instance Definition N Params := Factory.Build Params T …
 #[only="8.15.*"] Elpi Accumulate File "HB/common/compat_815.elpi".
 Elpi Accumulate File "HB/common/stdpp.elpi".
 Elpi Accumulate File "HB/common/database.elpi".
+#[skip="8.1[56].*"] Elpi Accumulate File "HB/common/compat_acc_clauses_all.elpi".
+#[only="8.1[56].*"] Elpi Accumulate File "HB/common/compat_acc_clauses_816.elpi".
 Elpi Accumulate File "HB/common/utils.elpi".
 Elpi Accumulate File "HB/common/log.elpi".
 Elpi Accumulate File "HB/common/synthesis.elpi".
@@ -680,6 +698,8 @@ Elpi Export HB.instance.
 #[only="8.15.*"] Elpi Accumulate File "HB/common/compat_815.elpi".
 Elpi Accumulate File "HB/common/stdpp.elpi".
 Elpi Accumulate File "HB/common/database.elpi".
+#[skip="8.1[56].*"] Elpi Accumulate File "HB/common/compat_acc_clauses_all.elpi".
+#[only="8.1[56].*"] Elpi Accumulate File "HB/common/compat_acc_clauses_816.elpi".
 Elpi Accumulate File "HB/common/utils.elpi".
 Elpi Accumulate File "HB/common/log.elpi".
 Elpi Accumulate File "HB/common/synthesis.elpi".
@@ -740,6 +760,8 @@ HB.end.
 #[only="8.15.*"] Elpi Accumulate File "HB/common/compat_815.elpi".
 Elpi Accumulate File "HB/common/stdpp.elpi".
 Elpi Accumulate File "HB/common/database.elpi".
+#[skip="8.1[56].*"] Elpi Accumulate File "HB/common/compat_acc_clauses_all.elpi".
+#[only="8.1[56].*"] Elpi Accumulate File "HB/common/compat_acc_clauses_816.elpi".
 Elpi Accumulate File "HB/common/utils.elpi".
 Elpi Accumulate File "HB/common/log.elpi".
 Elpi Accumulate File "HB/common/synthesis.elpi".
@@ -764,6 +786,8 @@ Elpi Export HB.builders.
 #[only="8.15.*"] Elpi Accumulate File "HB/common/compat_815.elpi".
 Elpi Accumulate File "HB/common/stdpp.elpi".
 Elpi Accumulate File "HB/common/database.elpi".
+#[skip="8.1[56].*"] Elpi Accumulate File "HB/common/compat_acc_clauses_all.elpi".
+#[only="8.1[56].*"] Elpi Accumulate File "HB/common/compat_acc_clauses_816.elpi".
 Elpi Accumulate File "HB/common/utils.elpi".
 Elpi Accumulate File "HB/common/log.elpi".
 Elpi Accumulate File "HB/common/synthesis.elpi".
@@ -816,6 +840,8 @@ Export Algebra.Exports.
 #[only="8.15.*"] Elpi Accumulate File "HB/common/compat_815.elpi".
 Elpi Accumulate File "HB/common/stdpp.elpi".
 Elpi Accumulate File "HB/common/database.elpi".
+#[skip="8.1[56].*"] Elpi Accumulate File "HB/common/compat_acc_clauses_all.elpi".
+#[only="8.1[56].*"] Elpi Accumulate File "HB/common/compat_acc_clauses_816.elpi".
 Elpi Accumulate File "HB/common/utils.elpi".
 Elpi Accumulate File "HB/common/log.elpi".
 Elpi Accumulate File "HB/export.elpi".
@@ -842,6 +868,8 @@ Elpi Export HB.export.
 #[only="8.15.*"] Elpi Accumulate File "HB/common/compat_815.elpi".
 Elpi Accumulate File "HB/common/stdpp.elpi".
 Elpi Accumulate File "HB/common/database.elpi".
+#[skip="8.1[56].*"] Elpi Accumulate File "HB/common/compat_acc_clauses_all.elpi".
+#[only="8.1[56].*"] Elpi Accumulate File "HB/common/compat_acc_clauses_816.elpi".
 Elpi Accumulate File "HB/common/utils.elpi".
 Elpi Accumulate File "HB/common/log.elpi".
 Elpi Accumulate File "HB/export.elpi".
@@ -888,6 +916,8 @@ Notation foo := foo.body.
 #[only="8.15.*"] Elpi Accumulate File "HB/common/compat_815.elpi".
 Elpi Accumulate File "HB/common/stdpp.elpi".
 Elpi Accumulate File "HB/common/database.elpi".
+#[skip="8.1[56].*"] Elpi Accumulate File "HB/common/compat_acc_clauses_all.elpi".
+#[only="8.1[56].*"] Elpi Accumulate File "HB/common/compat_acc_clauses_816.elpi".
 Elpi Accumulate File "HB/common/utils.elpi".
 Elpi Accumulate File "HB/common/log.elpi".
 Elpi Accumulate File "HB/lock.elpi".
@@ -937,6 +967,8 @@ HB.instance Definition _ : Ml ... T := ml.
 #[only="8.15.*"] Elpi Accumulate File "HB/common/compat_815.elpi".
 Elpi Accumulate File "HB/common/stdpp.elpi".
 Elpi Accumulate File "HB/common/database.elpi".
+#[skip="8.1[56].*"] Elpi Accumulate File "HB/common/compat_acc_clauses_all.elpi".
+#[only="8.1[56].*"] Elpi Accumulate File "HB/common/compat_acc_clauses_816.elpi".
 Elpi Accumulate File "HB/common/utils.elpi".
 Elpi Accumulate File "HB/common/log.elpi".
 Elpi Accumulate File "HB/common/synthesis.elpi".
@@ -973,6 +1005,8 @@ Elpi Accumulate Db hb.db.
 #[only="8.15.*"] Elpi Accumulate File "HB/common/compat_815.elpi".
 Elpi Accumulate File "HB/common/stdpp.elpi".
 Elpi Accumulate File "HB/common/database.elpi".
+#[skip="8.1[56].*"] Elpi Accumulate File "HB/common/compat_acc_clauses_all.elpi".
+#[only="8.1[56].*"] Elpi Accumulate File "HB/common/compat_acc_clauses_816.elpi".
 Elpi Accumulate File "HB/common/utils.elpi".
 Elpi Accumulate File "HB/common/log.elpi".
 Elpi Accumulate lp:{{

--- a/structures.v
+++ b/structures.v
@@ -142,9 +142,10 @@ pred is-structure o:gref.
 % the [F.Build T] abbreviation the term behind it has N arguments before T
 pred factory-builder-nparams o:constant, o:int.
 
-% [sub-class C1 C2] C1 is a sub-class of C2, see also sub-class? which computes
-% it on the fly
-pred sub-class o:classname, o:classname.
+% [sub-class C1 C2 Coercion12 NparamsCoercion] C1 is a sub-class of C2,
+% see also sub-class? which computes it on the fly
+:index (2 2 1)
+pred sub-class o:classname, o:classname, o:constant, o:int.
 
 % [gref-deps GR MLwP] is a (pre computed) list of dependencies of a know global
 % constant. The list is topologically sorted
@@ -225,13 +226,6 @@ pred decl-location o:gref, o:loc.
 
 % [docstring Loc Doc] links a location in the source text and some doc
 pred docstring o:loc, o:string.
-
-%% database for #[compress_coercions] %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-% coercions chains compression rules (we only care about non applicative
-% terms, since this is what you get when you apply coercions)
-:index (4)
-pred compress o:term, o:term.
 
 }}.
 

--- a/structures.v
+++ b/structures.v
@@ -239,6 +239,11 @@ pred docstring o:loc, o:string.
 
 #[arguments(raw)] Elpi Command HB.locate.
 Elpi Accumulate Db hb.db.
+(* Since it can become rather large, accumulating the DB is often by far the
+   most expensive accumulation. It is then worth sharing its cache between
+   the commands. To this end, we accumulate the DB first in each command to
+   ensure the same dependencies and maximize cache hits. For instance, this
+   can save a few (2 or 3) percents of total compilation time on MathComp. *)
 #[skip="8.15.*"] Elpi Accumulate File "HB/common/compat_all.elpi".
 #[only="8.15.*"] Elpi Accumulate File "HB/common/compat_815.elpi".
 Elpi Accumulate lp:{{
@@ -268,6 +273,7 @@ Elpi Export HB.locate.
 *)
 
 #[arguments(raw)] Elpi Command HB.about.
+Elpi Accumulate Db hb.db.
 #[skip="8.15.*"] Elpi Accumulate File "HB/common/compat_all.elpi".
 #[only="8.15.*"] Elpi Accumulate File "HB/common/compat_815.elpi".
 Elpi Accumulate File "HB/common/stdpp.elpi".
@@ -277,7 +283,6 @@ Elpi Accumulate File "HB/common/database.elpi".
 Elpi Accumulate File "HB/common/utils.elpi".
 Elpi Accumulate File "HB/common/log.elpi".
 Elpi Accumulate File "HB/about.elpi".
-Elpi Accumulate Db hb.db.
 Elpi Accumulate lp:{{
 
 main [str S] :- !, with-attributes (with-logging (about.main S)).
@@ -303,6 +308,7 @@ Elpi Export HB.about.
 *)
 
 #[arguments(raw)] Elpi Command HB.howto.
+Elpi Accumulate Db hb.db.
 #[skip="8.15.*"] Elpi Accumulate File "HB/common/compat_all.elpi".
 #[only="8.15.*"] Elpi Accumulate File "HB/common/compat_815.elpi".
 Elpi Accumulate File "HB/common/stdpp.elpi".
@@ -313,7 +319,6 @@ Elpi Accumulate File "HB/common/utils.elpi".
 Elpi Accumulate File "HB/common/log.elpi".
 Elpi Accumulate File "HB/about.elpi".
 Elpi Accumulate File "HB/howto.elpi".
-Elpi Accumulate Db hb.db.
 Elpi Accumulate lp:{{
 
 main [trm T, str STgt] :- !,
@@ -346,6 +351,7 @@ Elpi Export HB.howto.
 *)
 
 #[arguments(raw)] Elpi Command HB.status.
+Elpi Accumulate Db hb.db.
 #[skip="8.15.*"] Elpi Accumulate File "HB/common/compat_all.elpi".
 #[only="8.15.*"] Elpi Accumulate File "HB/common/compat_815.elpi".
 Elpi Accumulate File "HB/common/stdpp.elpi".
@@ -354,7 +360,6 @@ Elpi Accumulate File "HB/common/database.elpi".
 #[only="8.1[56].*"] Elpi Accumulate File "HB/common/compat_acc_clauses_816.elpi".
 Elpi Accumulate File "HB/common/utils.elpi".
 Elpi Accumulate File "HB/status.elpi".
-Elpi Accumulate Db hb.db.
 Elpi Accumulate lp:{{
 
 main [] :- !, status.print-hierarchy.
@@ -376,6 +381,7 @@ tred file.dot | xdot -
 *)
 
 #[arguments(raw)] Elpi Command HB.graph.
+Elpi Accumulate Db hb.db.
 #[skip="8.15.*"] Elpi Accumulate File "HB/common/compat_all.elpi".
 #[only="8.15.*"] Elpi Accumulate File "HB/common/compat_815.elpi".
 Elpi Accumulate File "HB/common/stdpp.elpi".
@@ -385,7 +391,6 @@ Elpi Accumulate File "HB/common/database.elpi".
 Elpi Accumulate File "HB/common/utils.elpi".
 Elpi Accumulate File "HB/common/log.elpi".
 Elpi Accumulate File "HB/graph.elpi".
-Elpi Accumulate Db hb.db.
 Elpi Accumulate lp:{{
 
 main [str File] :- with-attributes (with-logging (graph.to-file File)).
@@ -426,6 +431,7 @@ HB.mixin Record MixinName T of Factory1 T & … & FactoryN T := {
 *)
 
 #[arguments(raw)] Elpi Command HB.mixin.
+Elpi Accumulate Db hb.db.
 #[skip="8.15.*"] Elpi Accumulate File "HB/common/compat_all.elpi".
 #[only="8.15.*"] Elpi Accumulate File "HB/common/compat_815.elpi".
 Elpi Accumulate File "HB/common/stdpp.elpi".
@@ -440,7 +446,6 @@ Elpi Accumulate File "HB/instance.elpi".
 Elpi Accumulate File "HB/context.elpi".
 Elpi Accumulate File "HB/export.elpi".
 Elpi Accumulate File "HB/factory.elpi".
-Elpi Accumulate Db hb.db.
 Elpi Accumulate lp:{{
 
 main [A] :- A = indt-decl _, !,
@@ -599,6 +604,7 @@ HB.structure Definition StructureName params :=
 *)
 
 #[arguments(raw)] Elpi Command HB.structure.
+Elpi Accumulate Db hb.db.
 #[skip="8.15.*"] Elpi Accumulate File "HB/common/compat_all.elpi".
 #[only="8.15.*"] Elpi Accumulate File "HB/common/compat_815.elpi".
 Elpi Accumulate File "HB/common/stdpp.elpi".
@@ -614,7 +620,6 @@ Elpi Accumulate File "HB/instance.elpi".
 Elpi Accumulate File "HB/context.elpi".
 Elpi Accumulate File "HB/factory.elpi".
 Elpi Accumulate File "HB/structure.elpi".
-Elpi Accumulate Db hb.db.
 Elpi Accumulate lp:{{
 
 main [const-decl N (some B) Arity] :- !, std.do! [
@@ -655,6 +660,7 @@ HB.instance Definition N Params := Factory.Build Params T …
 *)
 
 #[arguments(raw)] Elpi Command HB.instance.
+Elpi Accumulate Db hb.db.
 #[skip="8.15.*"] Elpi Accumulate File "HB/common/compat_all.elpi".
 #[only="8.15.*"] Elpi Accumulate File "HB/common/compat_815.elpi".
 Elpi Accumulate File "HB/common/stdpp.elpi".
@@ -666,7 +672,6 @@ Elpi Accumulate File "HB/common/log.elpi".
 Elpi Accumulate File "HB/common/synthesis.elpi".
 Elpi Accumulate File "HB/context.elpi".
 Elpi Accumulate File "HB/instance.elpi".
-Elpi Accumulate Db hb.db.
 Elpi Accumulate lp:{{
 
 main [const-decl Name (some BodySkel) TyWPSkel] :- !,
@@ -688,6 +693,7 @@ Elpi Export HB.instance.
 (** [HB.factory] declares a factory. It has the same syntax of [HB.mixin] *)
 
 #[arguments(raw)] Elpi Command HB.factory.
+Elpi Accumulate Db hb.db.
 #[skip="8.15.*"] Elpi Accumulate File "HB/common/compat_all.elpi".
 #[only="8.15.*"] Elpi Accumulate File "HB/common/compat_815.elpi".
 Elpi Accumulate File "HB/common/stdpp.elpi".
@@ -702,7 +708,6 @@ Elpi Accumulate File "HB/instance.elpi".
 Elpi Accumulate File "HB/context.elpi".
 Elpi Accumulate File "HB/export.elpi".
 Elpi Accumulate File "HB/factory.elpi".
-Elpi Accumulate Db hb.db.
 Elpi Accumulate lp:{{
 main [A] :- (A = indt-decl _ ; A = const-decl _ _ _), !,
   with-attributes (with-logging (factory.declare A)).
@@ -750,6 +755,7 @@ HB.end.
 *)
 
 #[arguments(raw)] Elpi Command HB.builders.
+Elpi Accumulate Db hb.db.
 #[skip="8.15.*"] Elpi Accumulate File "HB/common/compat_all.elpi".
 #[only="8.15.*"] Elpi Accumulate File "HB/common/compat_815.elpi".
 Elpi Accumulate File "HB/common/stdpp.elpi".
@@ -765,7 +771,6 @@ Elpi Accumulate File "HB/context.elpi".
 Elpi Accumulate File "HB/export.elpi".
 Elpi Accumulate File "HB/factory.elpi".
 Elpi Accumulate File "HB/builders.elpi".
-Elpi Accumulate Db hb.db.
 Elpi Accumulate lp:{{
 main [ctx-decl C] :- !, with-attributes (with-logging (builders.begin C)).
 
@@ -776,6 +781,7 @@ Elpi Export HB.builders.
 
 
 #[arguments(raw)] Elpi Command HB.end.
+Elpi Accumulate Db hb.db.
 #[skip="8.15.*"] Elpi Accumulate File "HB/common/compat_all.elpi".
 #[only="8.15.*"] Elpi Accumulate File "HB/common/compat_815.elpi".
 Elpi Accumulate File "HB/common/stdpp.elpi".
@@ -789,7 +795,6 @@ Elpi Accumulate File "HB/instance.elpi".
 Elpi Accumulate File "HB/context.elpi".
 Elpi Accumulate File "HB/export.elpi".
 Elpi Accumulate File "HB/builders.elpi".
-Elpi Accumulate Db hb.db.
 Elpi Accumulate lp:{{
 main [] :- !, with-attributes (with-logging builders.end).
 main _ :- coq.error "Usage: HB.end.".
@@ -830,6 +835,7 @@ Export Algebra.Exports.
 *)
 
 #[arguments(raw)] Elpi Command HB.export.
+Elpi Accumulate Db hb.db.
 #[skip="8.15.*"] Elpi Accumulate File "HB/common/compat_all.elpi".
 #[only="8.15.*"] Elpi Accumulate File "HB/common/compat_815.elpi".
 Elpi Accumulate File "HB/common/stdpp.elpi".
@@ -839,7 +845,6 @@ Elpi Accumulate File "HB/common/database.elpi".
 Elpi Accumulate File "HB/common/utils.elpi".
 Elpi Accumulate File "HB/common/log.elpi".
 Elpi Accumulate File "HB/export.elpi".
-Elpi Accumulate Db hb.db.
 Elpi Accumulate lp:{{
 main [str M] :- !, with-attributes (with-logging (export.any M)).
 main _ :- coq.error "Usage: HB.export M.".
@@ -858,6 +863,7 @@ Elpi Export HB.export.
    (a module which is not closed yet) *)
 
 #[arguments(raw)] Elpi Command HB.reexport.
+Elpi Accumulate Db hb.db.
 #[skip="8.15.*"] Elpi Accumulate File "HB/common/compat_all.elpi".
 #[only="8.15.*"] Elpi Accumulate File "HB/common/compat_815.elpi".
 Elpi Accumulate File "HB/common/stdpp.elpi".
@@ -867,7 +873,6 @@ Elpi Accumulate File "HB/common/database.elpi".
 Elpi Accumulate File "HB/common/utils.elpi".
 Elpi Accumulate File "HB/common/log.elpi".
 Elpi Accumulate File "HB/export.elpi".
-Elpi Accumulate Db hb.db.
 Elpi Accumulate lp:{{
 main [] :- !, with-attributes (with-logging (export.reexport-all-modules-and-CS none)).
 main [str M] :- !, with-attributes (with-logging (export.reexport-all-modules-and-CS (some M))).
@@ -906,6 +911,7 @@ Notation foo := foo.body.
 *)
 
 #[arguments(raw)] Elpi Command HB.lock.
+Elpi Accumulate Db hb.db.
 #[skip="8.15.*"] Elpi Accumulate File "HB/common/compat_all.elpi".
 #[only="8.15.*"] Elpi Accumulate File "HB/common/compat_815.elpi".
 Elpi Accumulate File "HB/common/stdpp.elpi".
@@ -915,7 +921,6 @@ Elpi Accumulate File "HB/common/database.elpi".
 Elpi Accumulate File "HB/common/utils.elpi".
 Elpi Accumulate File "HB/common/log.elpi".
 Elpi Accumulate File "HB/lock.elpi".
-Elpi Accumulate Db hb.db.
 Elpi Accumulate lp:{{
 main [const-decl Name (some BoSkel) TySkel] :- !,
   with-attributes (with-logging (lock.lock-def Name TySkel BoSkel)).
@@ -957,6 +962,7 @@ HB.instance Definition _ : Ml ... T := ml.
 *)
 
 #[arguments(raw)] Elpi Command HB.declare.
+Elpi Accumulate Db hb.db.
 #[skip="8.15.*"] Elpi Accumulate File "HB/common/compat_all.elpi".
 #[only="8.15.*"] Elpi Accumulate File "HB/common/compat_815.elpi".
 Elpi Accumulate File "HB/common/stdpp.elpi".
@@ -971,7 +977,6 @@ Elpi Accumulate File "HB/export.elpi".
 Elpi Accumulate File "HB/instance.elpi".
 Elpi Accumulate File "HB/context.elpi".
 Elpi Accumulate File "HB/factory.elpi".
-Elpi Accumulate Db hb.db.
 Elpi Accumulate lp:{{
 
 main [Ctx] :- Ctx = ctx-decl _, !,

--- a/tests/about.v.out
+++ b/tests/about.v.out
@@ -112,7 +112,6 @@ HB: add comes from mixin AddMonoid_of_TYPE
 HB: AddAG.sort is a canonical projection
     (from "./examples/demo1/hierarchy_5.v", line 73)
 HB: AddAG.sort has the following canonical values:
-    - @eta 
     - Ring.sort (from "./examples/demo1/hierarchy_5.v", line 196)
     - Z 
 
@@ -135,7 +134,6 @@ HB: hierarchy_5_Ring_class__to__hierarchy_5_SemiRing_class is a coercion from
 HB: hierarchy_5_Ring__to__hierarchy_5_SemiRing is a coercion from
     Ring to SemiRing (from "./examples/demo1/hierarchy_5.v", line 196)
 
-HB: todo HB.about for builder from Ring_of_AddAG to BiNearRing_of_AddMonoid
 HB: synthesized in file File "(stdin)", line 5, column 0, character 127:
 Interactive Module hierarchy_5 started
 Interactive Module AddComoid started

--- a/tests/about.v.out.15
+++ b/tests/about.v.out.15
@@ -112,7 +112,6 @@ HB: add comes from mixin AddMonoid_of_TYPE
 HB: AddAG.sort is a canonical projection
     (from "./examples/demo1/hierarchy_5.v", line 73)
 HB: AddAG.sort has the following canonical values:
-    - @eta 
     - Ring.sort (from "./examples/demo1/hierarchy_5.v", line 196)
     - Z 
 
@@ -135,7 +134,6 @@ HB: hierarchy_5_Ring_class__to__hierarchy_5_SemiRing_class is a coercion from
 HB: hierarchy_5_Ring__to__hierarchy_5_SemiRing is a coercion from
     Ring to SemiRing (from "./examples/demo1/hierarchy_5.v", line 196)
 
-HB: todo HB.about for builder from Ring_of_AddAG to BiNearRing_of_AddMonoid
 HB: synthesized in file File "(stdin)", line 5, column 122, character 127:
 Interactive Module hierarchy_5 started
 Interactive Module AddComoid started

--- a/tests/hnf.v
+++ b/tests/hnf.v
@@ -10,9 +10,9 @@ HB.end.
 
 #[hnf] HB.instance Definition _ := f.Build nat (3 + 2).
 Print Datatypes_nat__canonical__hnf_S.
-Print HB_unnamed_mixin_12.
+Print HB_unnamed_mixin_8.
 
 HB.instance Definition _ := f.Build bool (3 + 2).
 Print Datatypes_bool__canonical__hnf_S.
-Print HB_unnamed_mixin_16.
+Print HB_unnamed_mixin_12.
 

--- a/tests/hnf.v.out
+++ b/tests/hnf.v.out
@@ -1,12 +1,12 @@
 Datatypes_nat__canonical__hnf_S =
-{| S.sort := nat; S.class := {| S.hnf_M_mixin := HB_unnamed_mixin_12 |} |}
+{| S.sort := nat; S.class := {| S.hnf_M_mixin := HB_unnamed_mixin_8 |} |}
      : S.type
-HB_unnamed_mixin_12 =
-{| M.x := f.y nat HB_unnamed_factory_10 + 1 |}
+HB_unnamed_mixin_8 =
+{| M.x := f.y nat HB_unnamed_factory_6 + 1 |}
      : M.axioms_ nat
 Datatypes_bool__canonical__hnf_S =
-{| S.sort := bool; S.class := {| S.hnf_M_mixin := HB_unnamed_mixin_16 |} |}
+{| S.sort := bool; S.class := {| S.hnf_M_mixin := HB_unnamed_mixin_12 |} |}
      : S.type
-HB_unnamed_mixin_16 =
-Builders_6.HB_unnamed_factory_8 bool HB_unnamed_factory_13
+HB_unnamed_mixin_12 =
+Builders_2.HB_unnamed_factory_4 bool HB_unnamed_factory_9
      : M.axioms_ bool

--- a/tests/hnf.v.out.15
+++ b/tests/hnf.v.out.15
@@ -1,12 +1,12 @@
 Datatypes_nat__canonical__hnf_S = 
-{| S.sort := nat; S.class := {| S.hnf_M_mixin := HB_unnamed_mixin_12 |} |}
+{| S.sort := nat; S.class := {| S.hnf_M_mixin := HB_unnamed_mixin_8 |} |}
      : S.type
-HB_unnamed_mixin_12 = 
-{| M.x := f.y nat HB_unnamed_factory_10 + 1 |}
+HB_unnamed_mixin_8 = 
+{| M.x := f.y nat HB_unnamed_factory_6 + 1 |}
      : M.axioms_ nat
 Datatypes_bool__canonical__hnf_S = 
-{| S.sort := bool; S.class := {| S.hnf_M_mixin := HB_unnamed_mixin_16 |} |}
+{| S.sort := bool; S.class := {| S.hnf_M_mixin := HB_unnamed_mixin_12 |} |}
      : S.type
-HB_unnamed_mixin_16 = 
-Builders_6.HB_unnamed_factory_8 bool HB_unnamed_factory_13
+HB_unnamed_mixin_12 = 
+Builders_2.HB_unnamed_factory_4 bool HB_unnamed_factory_9
      : M.axioms_ bool

--- a/tests/hnf.v.out.16
+++ b/tests/hnf.v.out.16
@@ -1,12 +1,12 @@
 Datatypes_nat__canonical__hnf_S = 
-{| S.sort := nat; S.class := {| S.hnf_M_mixin := HB_unnamed_mixin_12 |} |}
+{| S.sort := nat; S.class := {| S.hnf_M_mixin := HB_unnamed_mixin_8 |} |}
      : S.type
-HB_unnamed_mixin_12 = 
-{| M.x := f.y nat HB_unnamed_factory_10 + 1 |}
+HB_unnamed_mixin_8 = 
+{| M.x := f.y nat HB_unnamed_factory_6 + 1 |}
      : M.axioms_ nat
 Datatypes_bool__canonical__hnf_S = 
-{| S.sort := bool; S.class := {| S.hnf_M_mixin := HB_unnamed_mixin_16 |} |}
+{| S.sort := bool; S.class := {| S.hnf_M_mixin := HB_unnamed_mixin_12 |} |}
      : S.type
-HB_unnamed_mixin_16 = 
-Builders_6.HB_unnamed_factory_8 bool HB_unnamed_factory_13
+HB_unnamed_mixin_12 = 
+Builders_2.HB_unnamed_factory_4 bool HB_unnamed_factory_9
      : M.axioms_ bool


### PR DESCRIPTION
Compilation of MathComp:
* before: 22:57 (1.53 GB)
  * HB.structure: 05:42
  * HB.instance: 02:31
  * HB.mixin: 00:19
  * HB.factory: 00:32
  * HB.builders: 00:23
  * HB.pack(_for): 00:15                                                                                           
* after: 17.22 (1.27 GB)                                                                                           
  * HB.structure: 01:38                                                                                            
  * HB.instance: 02:21                                                                                             
  * HB.mixin: 00:18                                                                                                
  * HB.factory: 00:32                                                                                              
  * HB.builders: 00:23                                                                                             
  * HB.pack(_for): 00:15
* mathcomp1: 06:16 (0.97 GB) (time x 2.77 (memory x 1.31))

Compilation of Analysis:
* before: 26:24 (2.49 GB)
  * HB.structure: 03:22
  * HB.instance: 02:56
  * HB.mixin: 00:29
  * HB.factory: 00:27
  * HB.builders: 00:18
* after: 20:54 (1.79 GB)
  * HB.structure: 01:02
  * HB.instance: 02:44
  * HB.mixin: 00:27
  * HB.factory: 00:25
  * HB.builders: 00:17
* analysis master: 07:49 (1.55 GB) with HB 1.4 (time x 2.67 (memory x 1.15))  
  or 06:32 (1.25 GB) with same HB (time x 3.20 (memory x 1.43))
