### PR TITLE
Make primitive_class the default

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- **Removed** the `#[primitive_class]` attribute, making it the default.
+
 ## [1.6.0] - 2023-09-20
 
 Compatible with

--- a/HB/common/utils.elpi
+++ b/HB/common/utils.elpi
@@ -40,7 +40,6 @@ with-attributes P :-
     att "local" bool,
     att "fail" bool,
     att "doc" string,
-    att "primitive_class" bool,
     att "primitive" bool,
     att "non_forgetful_inheritance" bool,
     att "hnf" bool,

--- a/HB/structure.elpi
+++ b/HB/structure.elpi
@@ -466,9 +466,7 @@ declare-class+structure MLwP Sort
     synthesize-fields.body ClassDeclaration,
 
   std.assert-ok! (coq.typecheck-indt-decl ClassDeclaration) "declare-class: illtyped",
-  if (get-option "primitive_class" tt)
-    (@primitive! => log.coq.env.add-indt ClassDeclaration ClassInd)
-    (log.coq.env.add-indt ClassDeclaration ClassInd),
+  (@primitive! => log.coq.env.add-indt ClassDeclaration ClassInd),
 
   coq.env.projections ClassInd Projs,
   % TODO: put this code in a named clause

--- a/structures.v
+++ b/structures.v
@@ -583,7 +583,6 @@ HB.structure Definition StructureName params :=
   - [#[short(type="shortName")]] produces the abbreviation [shortName] for [Structure.type]
   - [#[short(pack="shortName")]] produces the abbreviation [shortName] for [HB.pack_for Structure.type]
   - [#[primitive]] experimental attribute to make the structure a primitive record,
-  - [#[primitive_class]] experimental attribute to make the class a primitive record,
   - [#[verbose]] for a verbose output.
 *)
 

--- a/tests/fix_loop.v
+++ b/tests/fix_loop.v
@@ -1,4 +1,4 @@
 From HB Require Import structures.
 
 HB.mixin Record M A := { x: nat }.
-#[primitive_class] HB.structure Definition S := { A of M A }.
+HB.structure Definition S := { A of M A }.

--- a/tests/primitive_records.v
+++ b/tests/primitive_records.v
@@ -12,7 +12,7 @@ Elpi Query lp:{{
   std.assert! (coq.env.record? Ind tt) "not primitive"
 }}.
 
-#[primitive, primitive_class]
+#[primitive]
 HB.structure Definition A := {T of hasA T}.
 
 Elpi Query lp:{{
@@ -33,7 +33,7 @@ HB.mixin Record HasMul T := {
   mulA: associative mul;
 }.
 
-#[primitive, primitive_class]
+#[primitive]
 HB.structure Definition Mul := { T of HasMul T }.
 
 #[primitive]
@@ -41,6 +41,6 @@ HB.mixin Record HasSq T of Mul T := {
   sq : T -> T;
   pmul : forall x y, sq (mul x y) = mul (sq x) (sq y);
 }.
-#[primitive, primitive_class]
+#[primitive]
 HB.structure Definition Sq := { T of HasSq T & Mul T }.
 Check erefl : Sq.sort _ = Mul.sort _.


### PR DESCRIPTION
Compilation of MathComp:

* before: 16:34 (1.37 GB)
* after: 14:20 (1.37 GB)
* mathcomp1: 06:16 (0.97 GB) (time x 2.29 (memory x 1.31))

Compilation of Analysis:

* before: 20:59 (1.81 GB)
* after: 12:30 (1.76 GB)
* analysis master: 07:49 (1.55 GB) with HB 1.4 (time x 1.60 (memory x 1.14))
  or 06:32 (1.25 GB) with HB 1.6 (time x 1.91 (memory x 1.41))