### PR TITLE
Fix test

### DIFF
--- a/tests/infer.v
+++ b/tests/infer.v
@@ -16,8 +16,7 @@ HB.mixin Record barm (A : Type) (P : foo.type) (B: Type) (T : Type) := {
 #[infer(P)]
 HB.structure Definition bar A P B := { T of barm A P B T }.
 
-#[skip="8.1[0-5].*"] HB.check (bar.type_ bool nat bool).
-#[skip="8.1[6-9].*", fail] HB.check (bar.type_ bool nat bool).
+HB.check (bar.type_ bool nat bool).
 Print bar.phant_type.
 Print bar.type.
 Check bar.type bool nat bool.


### PR DESCRIPTION
Fixes #399

Since we dropped compatibility with Coq < 8.16, it is safe to remove the regexs altogthers.