### PR TITLE
at the end of HB.howto output, it suggests a link to a guide on how to declare mathcomp instances 

### DIFF
--- a/HB/howto.elpi
+++ b/HB/howto.elpi
@@ -148,7 +148,8 @@ pp-solutions LLF :-
     str "HB: solutions (use 'HB.about F.Build' to see the arguments of each factory F):",
     {about.bulletize SLLF pp-solution}],
   % print
-  coq.say {coq.pp->string PpSolutions},  
+  coq.say {coq.pp->string PpSolutions},
+  coq.say "For a guide on declaring MathComp instances please refer to the following link: https://github.com/math-comp/math-comp/wiki/How-to-declare-MathComp-instances",
   coq.say.
 
 pred pp-solution i:list factoryname, o:coq.pp.

--- a/HB/howto.elpi
+++ b/HB/howto.elpi
@@ -149,6 +149,7 @@ pp-solutions LLF :-
     {about.bulletize SLLF pp-solution}],
   % print
   coq.say {coq.pp->string PpSolutions},
+  coq.say,
   coq.say "For a guide on declaring MathComp instances please refer to the following link: https://github.com/math-comp/math-comp/wiki/How-to-declare-MathComp-instances",
   coq.say.
 

--- a/tests/howto.v.out
+++ b/tests/howto.v.out
@@ -8,6 +8,7 @@ HB: solutions (use 'HB.about F.Build' to see the arguments of each factory F):
     - AddComoid_of_TYPE; AddAG_of_AddComoid; Ring_of_AddAG
     - AddComoid_of_TYPE; AddAG_of_AddComoid; SemiRing_of_AddComoid
     - AddMonoid_of_TYPE; AddComoid_of_AddMonoid; Ring_of_AddComoid
+
 For a guide on declaring MathComp instances please refer to the following link: https://github.com/math-comp/math-comp/wiki/How-to-declare-MathComp-instances
 
 HB: solutions (use 'HB.about F.Build' to see the arguments of each factory F):
@@ -16,6 +17,7 @@ HB: solutions (use 'HB.about F.Build' to see the arguments of each factory F):
     - AddAG_of_TYPE; Ring_of_AddAG
     - AddAG_of_TYPE; SemiRing_of_AddComoid
     - AddComoid_of_TYPE; Ring_of_AddComoid
+
 For a guide on declaring MathComp instances please refer to the following link: https://github.com/math-comp/math-comp/wiki/How-to-declare-MathComp-instances
 
 HB: solutions (use 'HB.about F.Build' to see the arguments of each factory F):
@@ -28,6 +30,7 @@ HB: solutions (use 'HB.about F.Build' to see the arguments of each factory F):
     - AddComoid_of_TYPE; AddAG_of_AddComoid; Ring_of_AddAG
     - AddComoid_of_TYPE; AddAG_of_AddComoid; SemiRing_of_AddComoid
     - AddMonoid_of_TYPE; AddComoid_of_AddMonoid; Ring_of_AddComoid
+
 For a guide on declaring MathComp instances please refer to the following link: https://github.com/math-comp/math-comp/wiki/How-to-declare-MathComp-instances
 
 HB: solutions (use 'HB.about F.Build' to see the arguments of each factory F):
@@ -36,6 +39,7 @@ HB: solutions (use 'HB.about F.Build' to see the arguments of each factory F):
     - AddAG_of_TYPE; Ring_of_AddAG
     - AddAG_of_TYPE; SemiRing_of_AddComoid
     - AddComoid_of_TYPE; Ring_of_AddComoid
+
 For a guide on declaring MathComp instances please refer to the following link: https://github.com/math-comp/math-comp/wiki/How-to-declare-MathComp-instances
 
 The command has indeed failed with message:
@@ -45,18 +49,21 @@ HB: solutions (use 'HB.about F.Build' to see the arguments of each factory F):
     - AddAG_of_AddComoid; BiNearRing_of_AddMonoid
     - AddAG_of_AddComoid; Ring_of_AddAG
     - AddAG_of_AddComoid; SemiRing_of_AddComoid
+
 For a guide on declaring MathComp instances please refer to the following link: https://github.com/math-comp/math-comp/wiki/How-to-declare-MathComp-instances
 
 HB: solutions (use 'HB.about F.Build' to see the arguments of each factory F):
     - BiNearRing_of_AddMonoid
     - Ring_of_AddAG
     - SemiRing_of_AddComoid
+
 For a guide on declaring MathComp instances please refer to the following link: https://github.com/math-comp/math-comp/wiki/How-to-declare-MathComp-instances
 
 HB: solutions (use 'HB.about F.Build' to see the arguments of each factory F):
     - BiNearRing_of_AddMonoid
     - Ring_of_AddAG
     - SemiRing_of_AddComoid
+
 For a guide on declaring MathComp instances please refer to the following link: https://github.com/math-comp/math-comp/wiki/How-to-declare-MathComp-instances
 
 HB: nothing to do.

--- a/tests/howto.v.out
+++ b/tests/howto.v.out
@@ -8,6 +8,7 @@ HB: solutions (use 'HB.about F.Build' to see the arguments of each factory F):
     - AddComoid_of_TYPE; AddAG_of_AddComoid; Ring_of_AddAG
     - AddComoid_of_TYPE; AddAG_of_AddComoid; SemiRing_of_AddComoid
     - AddMonoid_of_TYPE; AddComoid_of_AddMonoid; Ring_of_AddComoid
+For a guide on declaring MathComp instances please refer to the following link: https://github.com/math-comp/math-comp/wiki/How-to-declare-MathComp-instances
 
 HB: solutions (use 'HB.about F.Build' to see the arguments of each factory F):
     - Ring_of_TYPE
@@ -15,6 +16,7 @@ HB: solutions (use 'HB.about F.Build' to see the arguments of each factory F):
     - AddAG_of_TYPE; Ring_of_AddAG
     - AddAG_of_TYPE; SemiRing_of_AddComoid
     - AddComoid_of_TYPE; Ring_of_AddComoid
+For a guide on declaring MathComp instances please refer to the following link: https://github.com/math-comp/math-comp/wiki/How-to-declare-MathComp-instances
 
 HB: solutions (use 'HB.about F.Build' to see the arguments of each factory F):
     - Ring_of_TYPE
@@ -26,6 +28,7 @@ HB: solutions (use 'HB.about F.Build' to see the arguments of each factory F):
     - AddComoid_of_TYPE; AddAG_of_AddComoid; Ring_of_AddAG
     - AddComoid_of_TYPE; AddAG_of_AddComoid; SemiRing_of_AddComoid
     - AddMonoid_of_TYPE; AddComoid_of_AddMonoid; Ring_of_AddComoid
+For a guide on declaring MathComp instances please refer to the following link: https://github.com/math-comp/math-comp/wiki/How-to-declare-MathComp-instances
 
 HB: solutions (use 'HB.about F.Build' to see the arguments of each factory F):
     - Ring_of_TYPE
@@ -33,6 +36,7 @@ HB: solutions (use 'HB.about F.Build' to see the arguments of each factory F):
     - AddAG_of_TYPE; Ring_of_AddAG
     - AddAG_of_TYPE; SemiRing_of_AddComoid
     - AddComoid_of_TYPE; Ring_of_AddComoid
+For a guide on declaring MathComp instances please refer to the following link: https://github.com/math-comp/math-comp/wiki/How-to-declare-MathComp-instances
 
 The command has indeed failed with message:
 HB: no solution found, try to increase search depth.
@@ -41,15 +45,18 @@ HB: solutions (use 'HB.about F.Build' to see the arguments of each factory F):
     - AddAG_of_AddComoid; BiNearRing_of_AddMonoid
     - AddAG_of_AddComoid; Ring_of_AddAG
     - AddAG_of_AddComoid; SemiRing_of_AddComoid
+For a guide on declaring MathComp instances please refer to the following link: https://github.com/math-comp/math-comp/wiki/How-to-declare-MathComp-instances
 
 HB: solutions (use 'HB.about F.Build' to see the arguments of each factory F):
     - BiNearRing_of_AddMonoid
     - Ring_of_AddAG
     - SemiRing_of_AddComoid
+For a guide on declaring MathComp instances please refer to the following link: https://github.com/math-comp/math-comp/wiki/How-to-declare-MathComp-instances
 
 HB: solutions (use 'HB.about F.Build' to see the arguments of each factory F):
     - BiNearRing_of_AddMonoid
     - Ring_of_AddAG
     - SemiRing_of_AddComoid
+For a guide on declaring MathComp instances please refer to the following link: https://github.com/math-comp/math-comp/wiki/How-to-declare-MathComp-instances
 
 HB: nothing to do.


### PR DESCRIPTION
At CUDW 2024, we discussed the idea of ​​writing a guide for declaring mathcomp instances. 
This PR refers to that guide.