### PR TITLE
Allow to declare instances on `(fun ... => key ...)`

### DIFF
--- a/HB/common/stdpp.elpi
+++ b/HB/common/stdpp.elpi
@@ -302,6 +302,10 @@ term->cs-pattern (sort U) (cs-sort U) :- !.
 term->cs-pattern T (cs-gref GR) :- coq.term->gref T GR, !.
 term->cs-pattern T _ :- coq.error T "HB database: is not a valid canonical key".
 
+func coq.term->gref term -> gref.
+:before "term->gref:fail"
+coq.term->gref (fun N Ty F) GR :- !, @pi-decl N Ty x\ coq.term->gref (F x) GR.
+
 % ---------------------------------------------------------------------
 % kit for closing a term by abstracting evars with lambdas
 % we use constraints to attach to holes a number


### PR DESCRIPTION
Let's say I want to declare a morphism instance on `fun x => f x y` (`f ^~ y` in MC) for some binary function `f` and `y`. Currently, HB complains:
```
Error:
term->gref: input has no global reference: ...
```

Canonical structures allow such instance declarations (cf. https://rocq-prover.org/doc/v9.2/refman/language/extensions/canonical.html#declaration-of-canonical-structures). So, this PR tries to relax the restriction on the HB side.

I'm unsure whether this small change suffices. I will test it with my real example and add a test case.